### PR TITLE
Improve login speed and UX

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/MyApplication.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/MyApplication.java
@@ -2,11 +2,18 @@ package co.median.android.a2025_theangels_new;
 
 import android.app.Application;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreSettings;
 
 public class MyApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
         FirebaseApp.initializeApp(this);
+        FirebaseFirestore firestore = FirebaseFirestore.getInstance();
+        FirebaseFirestoreSettings settings = new FirebaseFirestoreSettings.Builder()
+                .setPersistenceEnabled(true)
+                .build();
+        firestore.setFirestoreSettings(settings);
     }
 }

--- a/app/src/main/java/co/median/android/a2025_theangels_new/activities/MainActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/activities/MainActivity.java
@@ -10,7 +10,7 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;
 import android.widget.Button;
-import com.google.firebase.FirebaseApp;
+import android.widget.ProgressBar;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException;
@@ -34,6 +34,7 @@ public class MainActivity extends BaseActivity {
     // =======================================
     private TextInputEditText usernameInput, passwordInput;
     private Button loginButton, registerButton;
+    private ProgressBar loginProgressBar;
 
     // =======================================
     // onCreate - Initializes the login screen and handles onboarding check
@@ -73,6 +74,7 @@ public class MainActivity extends BaseActivity {
         passwordInput = findViewById(R.id.passwordInput);
         loginButton = findViewById(R.id.loginButton);
         registerButton = findViewById(R.id.registerButton);
+        loginProgressBar = findViewById(R.id.loginProgressBar);
 
         // Initially disable login button
         loginButton.setEnabled(false);
@@ -104,8 +106,12 @@ public class MainActivity extends BaseActivity {
                 return;
             }
 
+            loginButton.setEnabled(false);
+            loginProgressBar.setVisibility(View.VISIBLE);
+
             FirebaseAuth.getInstance().signInWithEmailAndPassword(email, password)
                     .addOnCompleteListener(this, task -> {
+                        loginProgressBar.setVisibility(View.GONE);
                         if (task.isSuccessful()) {
                             String uid = FirebaseAuth.getInstance().getCurrentUser().getUid();
                             UserDataManager.loadUserDetails(uid, session -> {
@@ -114,6 +120,7 @@ public class MainActivity extends BaseActivity {
                                 finish();
                             });
                         } else {
+                            loginButton.setEnabled(true);
                             Exception e = task.getException();
                             if (e instanceof FirebaseAuthInvalidUserException) {
                                 Toast.makeText(this, "המשתמש לא קיים", Toast.LENGTH_SHORT).show();
@@ -140,8 +147,10 @@ public class MainActivity extends BaseActivity {
     protected void onStart() {
         super.onStart();
         if (FirebaseAuth.getInstance().getCurrentUser() != null) {
+            loginProgressBar.setVisibility(View.VISIBLE);
             String uid = FirebaseAuth.getInstance().getCurrentUser().getUid();
             UserDataManager.loadUserDetails(uid, session -> {
+                loginProgressBar.setVisibility(View.GONE);
                 startActivity(new Intent(MainActivity.this, HomeActivity.class));
                 finish();
             });

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -106,4 +106,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
+    <ProgressBar
+        android:id="@+id/loginProgressBar"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/formCard"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- enable Firestore persistence in `MyApplication`
- show a progress bar during login
- disable login button while awaiting Firebase
- show progress on automatic sign-in

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684ab103a46c83308828f06a28535f0f