### PR TITLE
Improve education screens and adapter

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/activities/EducationDetailsActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/activities/EducationDetailsActivity.java
@@ -5,6 +5,10 @@ package co.median.android.a2025_theangels_new.activities;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.bumptech.glide.Glide;
 
 import co.median.android.a2025_theangels_new.R;
 
@@ -21,12 +25,29 @@ public class EducationDetailsActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
         showTopBar(false);
         showBottomBar(false);
-        setContentView(R.layout.activity_education_details);
 
-        // Handle back button click
+        // Retrieve data passed from the list screen
+        Intent intent = getIntent();
+        String title = intent.getStringExtra("eduTitle");
+        String data = intent.getStringExtra("eduData");
+        String imageUrl = intent.getStringExtra("eduImageURL");
+
+        TextView tvTitle = findViewById(R.id.title);
+        TextView tvContent = findViewById(R.id.education_content);
+        ImageView ivHeader = findViewById(R.id.header_image);
+
+        if (tvTitle != null) {
+            tvTitle.setText(title);
+        }
+        if (tvContent != null) {
+            tvContent.setText(data);
+        }
+        if (ivHeader != null) {
+            Glide.with(this).load(imageUrl).placeholder(R.drawable.training1).into(ivHeader);
+        }
+
+        // Back button
         findViewById(R.id.btn_back).setOnClickListener(v -> {
-            Intent intent = new Intent(EducationDetailsActivity.this, EducationActivity.class);
-            startActivity(intent);
             finish();
         });
     }

--- a/app/src/main/java/co/median/android/a2025_theangels_new/activities/Trainingadapter.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/activities/Trainingadapter.java
@@ -6,11 +6,12 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
-import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
+
+import com.bumptech.glide.Glide;
 
 import java.util.ArrayList;
 
@@ -50,22 +51,22 @@ public class Trainingadapter extends ArrayAdapter<Training> {
 
         TextView title = rootView.findViewById(R.id.training_title);
         ImageView picture = rootView.findViewById(R.id.training_picture);
-        Button button = rootView.findViewById(R.id.training_button);
 
         if (training != null) {
             title.setText(training.getEduTitle());
 
-            int imageResId = context.getResources().getIdentifier(
-                    training.getEduImageURL(), "drawable", context.getPackageName());
+            // Load image from URL using Glide. Fallback to placeholder if needed
+            Glide.with(context)
+                    .load(training.getEduImageURL())
+                    .placeholder(R.drawable.training1)
+                    .into(picture);
 
-            if (imageResId != 0) {
-                picture.setImageResource(imageResId);
-            } else {
-                picture.setImageResource(R.drawable.training1);
-            }
-
-            button.setOnClickListener(v -> {
+            // Open details screen when the card is clicked
+            rootView.setOnClickListener(v -> {
                 Intent intent = new Intent(context, EducationDetailsActivity.class);
+                intent.putExtra("eduTitle", training.getEduTitle());
+                intent.putExtra("eduData", training.getEduData());
+                intent.putExtra("eduImageURL", training.getEduImageURL());
                 context.startActivity(intent);
             });
         }

--- a/app/src/main/java/co/median/android/a2025_theangels_new/services/TrainingDataManager.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/services/TrainingDataManager.java
@@ -23,7 +23,9 @@ public class TrainingDataManager {
     public static void getAllTrainings(TrainingCallback callback) {
         Log.d(TAG, "getAllTrainings called - starting Firestore fetch");
 
-        FirebaseFirestore.getInstance().collection("trainings")
+        // Fetch education documents from Firestore. Collection name is
+        // "education" as defined in the DB.
+        FirebaseFirestore.getInstance().collection("education")
                 .get()
                 .addOnSuccessListener(queryDocumentSnapshots -> {
                     ArrayList<Training> trainings = new ArrayList<>();

--- a/app/src/main/res/layout/activity_education_details.xml
+++ b/app/src/main/res/layout/activity_education_details.xml
@@ -1,9 +1,10 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/white"
-    android:padding="0dp">
+    android:orientation="vertical"
+    android:background="@android:color/white">
 
     <LinearLayout
         android:id="@+id/header_container"
@@ -13,8 +14,7 @@
         android:gravity="center_vertical"
         android:background="@color/blue_gradient_start"
         android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:paddingTop="5dp">
+        android:paddingEnd="16dp">
 
         <ImageView
             android:id="@+id/btn_back"
@@ -23,138 +23,44 @@
             android:src="@drawable/ic_back_arrow"
             android:contentDescription="@string/back"
             android:padding="4dp"
-            android:layout_marginEnd="3dp"/>
+            android:layout_marginEnd="3dp" />
 
         <TextView
             android:id="@+id/title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/defib_title"
             android:textSize="20sp"
             android:textStyle="bold"
-            android:textColor="@android:color/white"/>
+            android:textColor="@android:color/white" />
     </LinearLayout>
 
     <ImageView
         android:id="@+id/header_image"
         android:layout_width="match_parent"
-        android:layout_height="120dp"
+        android:layout_height="160dp"
         android:scaleType="centerCrop"
-        android:src="@drawable/defibrillator"
-        android:layout_below="@id/header_container"/>
+        android:src="@drawable/training1" />
 
     <androidx.cardview.widget.CardView
-        android:id="@+id/training_title_card"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:cardCornerRadius="12dp"
-        app:cardElevation="8dp"
-        android:padding="6dp"
-        android:layout_margin="9dp"
-        android:layout_below="@id/header_image">
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_margin="12dp"
+        app:cardCornerRadius="8dp"
+        app:cardElevation="6dp">
 
-        <LinearLayout
+        <ScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:layout_height="match_parent"
+            android:padding="16dp">
 
             <TextView
+                android:id="@+id/education_content"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/defib_intro"
-                android:textSize="13sp"
                 android:textColor="@android:color/black"
-                android:gravity="center"/>
-        </LinearLayout>
+                android:textSize="16sp" />
+        </ScrollView>
     </androidx.cardview.widget.CardView>
 
-    <androidx.cardview.widget.CardView
-        android:id="@+id/training_content_card"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:cardCornerRadius="5dp"
-        app:cardElevation="8dp"
-        android:padding="16dp"
-        android:layout_margin="4dp"
-        android:layout_below="@id/training_title_card">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/step1_title"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                android:textColor="@android:color/black"
-                android:layout_marginBottom="6dp"/>
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/step1_text"
-                android:textSize="16sp"
-                android:textColor="@android:color/black"
-                android:layout_marginBottom="8dp"/>
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/step2_title"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                android:textColor="@android:color/black"
-                android:layout_marginBottom="6dp"/>
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/step2_text"
-                android:textSize="16sp"
-                android:textColor="@android:color/black"/>
-
-            <ImageView
-                android:id="@+id/defibrillator_image"
-                android:layout_width="match_parent"
-                android:layout_height="140dp"
-                android:scaleType="centerCrop"
-                android:src="@drawable/image_def" />
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/step3_title"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                android:textColor="@android:color/black"
-                android:layout_marginBottom="6dp"/>
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/step3_text"
-                android:textSize="16sp"
-                android:textColor="@android:color/black"/>
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/step4_title"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                android:textColor="@android:color/black"
-                android:layout_marginBottom="6dp"/>
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/step4_text"
-                android:textSize="16sp"
-                android:textColor="@android:color/black"/>
-        </LinearLayout>
-    </androidx.cardview.widget.CardView>
-
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/training_item.xml
+++ b/app/src/main/res/layout/training_item.xml
@@ -4,8 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
-    app:cardCornerRadius="16dp"
-    app:cardElevation="4dp">
+    app:cardCornerRadius="12dp"
+    app:cardElevation="6dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -14,8 +14,8 @@
 
         <ImageView
             android:id="@+id/training_picture"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
+            android:layout_width="80dp"
+            android:layout_height="80dp"
             android:scaleType="centerCrop"
             android:src="@drawable/training1"
             app:layout_constraintTop_toTopOf="parent"
@@ -34,15 +34,8 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@id/training_picture" />
 
-        <Button
-            android:id="@+id/training_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="להדרכה המלאה"
-            app:layout_constraintTop_toBottomOf="@id/training_title"
-            app:layout_constraintStart_toStartOf="@id/training_title"
-            app:layout_constraintEnd_toEndOf="@id/training_title"
-            android:layout_marginTop="8dp"/>
+        
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.cardview.widget.CardView>
+


### PR DESCRIPTION
## Summary
- switch Firestore collection to `education`
- load training images via Glide and open detail screen on card tap
- show training data dynamically in EducationDetailsActivity
- revamp `activity_education_details.xml` layout
- refresh training item card UI

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684ab541c3508330b6c035126fe7d717