### PR TITLE
Improve event card design and load status color

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/activities/EventsActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/activities/EventsActivity.java
@@ -13,6 +13,7 @@ import co.median.android.a2025_theangels_new.R;
 import co.median.android.a2025_theangels_new.models.Event;
 import co.median.android.a2025_theangels_new.services.EventDataManager;
 import co.median.android.a2025_theangels_new.services.EventTypeDataManager;
+import co.median.android.a2025_theangels_new.services.EventStatusDataManager;
 import co.median.android.a2025_theangels_new.models.EventType;
 
 public class EventsActivity extends BaseActivity {
@@ -23,6 +24,7 @@ public class EventsActivity extends BaseActivity {
     private EventsAdapter adapter;
     private ArrayList<Event> events;
     private Map<String, String> typeImageMap = new HashMap<>();
+    private Map<String, String> statusColorMap = new HashMap<>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -47,12 +49,29 @@ public class EventsActivity extends BaseActivity {
                     typeImageMap.put(type.getTypeName(), type.getTypeImageURL());
                 }
                 adapter.setEventTypeImages(typeImageMap);
-                loadEventsFromFirestore();
+                loadEventStatuses();
             }
 
             @Override
             public void onError(Exception e) {
                 Log.e(TAG, "Error loading event types", e);
+                loadEventStatuses();
+            }
+        });
+    }
+
+    private void loadEventStatuses() {
+        EventStatusDataManager.getAllEventStatuses(new EventStatusDataManager.EventStatusCallback() {
+            @Override
+            public void onStatusesLoaded(Map<String, String> statusMap) {
+                statusColorMap.putAll(statusMap);
+                adapter.setEventStatusColors(statusColorMap);
+                loadEventsFromFirestore();
+            }
+
+            @Override
+            public void onError(Exception e) {
+                Log.e(TAG, "Error loading event statuses", e);
                 loadEventsFromFirestore();
             }
         });

--- a/app/src/main/java/co/median/android/a2025_theangels_new/models/EventStatus.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/models/EventStatus.java
@@ -1,0 +1,24 @@
+package co.median.android.a2025_theangels_new.models;
+
+public class EventStatus {
+    private String statusName;
+    private String statusColor;
+
+    public EventStatus() {}
+
+    public String getStatusName() {
+        return statusName;
+    }
+
+    public void setStatusName(String statusName) {
+        this.statusName = statusName;
+    }
+
+    public String getStatusColor() {
+        return statusColor;
+    }
+
+    public void setStatusColor(String statusColor) {
+        this.statusColor = statusColor;
+    }
+}

--- a/app/src/main/java/co/median/android/a2025_theangels_new/models/UserBasicInfo.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/models/UserBasicInfo.java
@@ -1,0 +1,39 @@
+package co.median.android.a2025_theangels_new.models;
+
+public class UserBasicInfo {
+    private String firstName;
+    private String lastName;
+    private String imageURL;
+
+    public UserBasicInfo() {}
+
+    public UserBasicInfo(String firstName, String lastName, String imageURL) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.imageURL = imageURL;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getImageURL() {
+        return imageURL;
+    }
+
+    public void setImageURL(String imageURL) {
+        this.imageURL = imageURL;
+    }
+}

--- a/app/src/main/java/co/median/android/a2025_theangels_new/services/EventStatusDataManager.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/services/EventStatusDataManager.java
@@ -1,0 +1,36 @@
+package co.median.android.a2025_theangels_new.services;
+
+import android.util.Log;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import java.util.HashMap;
+import java.util.Map;
+
+public class EventStatusDataManager {
+    private static final String TAG = "EventStatusDataManager";
+
+    public interface EventStatusCallback {
+        void onStatusesLoaded(Map<String, String> statusMap);
+        void onError(Exception e);
+    }
+
+    public static void getAllEventStatuses(EventStatusCallback callback) {
+        FirebaseFirestore.getInstance().collection("eventStatus")
+                .get()
+                .addOnSuccessListener(queryDocumentSnapshots -> {
+                    Map<String, String> map = new HashMap<>();
+                    for (DocumentSnapshot doc : queryDocumentSnapshots.getDocuments()) {
+                        String name = doc.getString("statusName");
+                        String color = doc.getString("statusColor");
+                        if (name != null && color != null) {
+                            map.put(name, color);
+                        }
+                    }
+                    callback.onStatusesLoaded(map);
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Error fetching event statuses", e);
+                    callback.onError(e);
+                });
+    }
+}

--- a/app/src/main/java/co/median/android/a2025_theangels_new/services/UserDataManager.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/services/UserDataManager.java
@@ -123,4 +123,22 @@ public class UserDataManager {
                 });
     }
 
+    public static void loadBasicUserInfo(String uid, Consumer<co.median.android.a2025_theangels_new.models.UserBasicInfo> callback) {
+        db.collection("users").document(uid).get()
+                .addOnSuccessListener(document -> {
+                    if (document != null && document.exists()) {
+                        String firstName = document.getString("firstName");
+                        String lastName = document.getString("lastName");
+                        String imageURL = document.getString("imageURL");
+                        callback.accept(new co.median.android.a2025_theangels_new.models.UserBasicInfo(firstName, lastName, imageURL));
+                    } else {
+                        callback.accept(null);
+                    }
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "שגיאה בשליפת נתוני משתמש בסיסיים", e);
+                    callback.accept(null);
+                });
+    }
+
 }

--- a/app/src/main/res/drawable/status_label_bg.xml
+++ b/app/src/main/res/drawable/status_label_bg.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="8dp"/>
+    <solid android:color="@color/event_status_color"/>
+</shape>

--- a/app/src/main/res/layout/event.xml
+++ b/app/src/main/res/layout/event.xml
@@ -12,68 +12,131 @@
         android:layout_height="wrap_content"
         android:padding="16dp">
 
+        <TextView
+            android:id="@+id/event_status_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:text="סטטוס"
+            android:textColor="@android:color/white"
+            android:textSize="12sp"
+            android:background="@drawable/status_label_bg"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <ImageView
             android:id="@+id/event_picture"
             android:layout_width="64dp"
             android:layout_height="64dp"
+            android:layout_marginStart="8dp"
             android:scaleType="centerCrop"
             android:src="@drawable/event_medical"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent" />
 
-        <LinearLayout
-            android:id="@+id/event_info"
+        <TextView
+            android:id="@+id/event_case"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
             android:layout_marginEnd="8dp"
+            android:text="אירוע רפואי"
+            android:textColor="@android:color/black"
+            android:textStyle="bold"
+            android:textSize="16sp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@id/event_picture"
-            app:layout_constraintTop_toTopOf="@id/event_picture"
-            app:layout_constraintBottom_toBottomOf="@id/event_picture">
+            app:layout_constraintTop_toTopOf="@id/event_picture" />
+
+        <TextView
+            android:id="@+id/event_date"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="8dp"
+            android:text="12/12/2024 10:30"
+            android:textColor="@android:color/black"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/event_picture"
+            app:layout_constraintTop_toBottomOf="@id/event_case" />
+
+        <LinearLayout
+            android:id="@+id/volunteer_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/event_picture"
+            app:layout_constraintTop_toBottomOf="@id/event_date">
+
+            <ImageView
+                android:id="@+id/volunteer_image"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="4dp"
+                android:background="@drawable/circle_image"
+                android:scaleType="centerCrop"
+                android:src="@drawable/newuserpic" />
 
             <TextView
-                android:id="@+id/event_case"
+                android:id="@+id/volunteer_name"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="קטגוריה"
+                android:layout_marginEnd="4dp"
+                android:text="יונתן אזולאי"
+                android:textColor="@android:color/black"
+                android:textSize="14sp" />
+
+            <TextView
+                android:id="@+id/volunteer_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="מתנדב:"
                 android:textColor="@android:color/black"
                 android:textStyle="bold"
-                android:textSize="16sp" />
-
-            <TextView
-                android:id="@+id/event_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="תאריך"
-                android:textColor="@android:color/black"
                 android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/event_status"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="סטטוס"
-                android:textColor="@android:color/black"
-                android:textSize="14sp" />
-
-            <RatingBar
-                android:id="@+id/event_rating"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:numStars="5"
-                android:stepSize="1"
-                android:isIndicator="true"
-                style="?android:attr/ratingBarStyleSmall" />
-
-            <Button
-                android:id="@+id/details_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="לפרטי האירוע" />
         </LinearLayout>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        <LinearLayout
+            android:id="@+id/rating_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/event_picture"
+            app:layout_constraintTop_toBottomOf="@id/volunteer_container">
 
+            <ImageView
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:src="@drawable/ic_star" />
+
+            <TextView
+                android:id="@+id/event_rating_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:text="דירוג: 5"
+                android:textColor="@android:color/black"
+                android:textSize="14sp" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/details_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:layout_marginTop="6dp"
+            android:background="@drawable/button_gradient"
+            android:text="לפרטי האירוע"
+            android:textColor="@android:color/white"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/rating_container" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
## Summary
- redesign event card layout
- fetch volunteer details and status colors from Firestore
- show dynamic status label color in event card
- include models for event status and user info
- update EventsActivity and adapter to use new data

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684abcb371b8833080b68cfd1c7a605d