### PR TITLE
Redesign event card layout

### DIFF
--- a/app/src/main/res/layout/event.xml
+++ b/app/src/main/res/layout/event.xml
@@ -3,14 +3,17 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="8dp"
+    android:layout_margin="16dp"
     app:cardCornerRadius="12dp"
-    app:cardElevation="6dp">
+    app:cardElevation="6dp"
+    app:cardUseCompatPadding="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp">
+        android:padding="16dp"
+        android:layoutDirection="rtl"
+        android:minHeight="96dp">
 
         <TextView
             android:id="@+id/event_status_label"
@@ -31,7 +34,7 @@
             android:layout_marginStart="8dp"
             android:scaleType="centerCrop"
             android:src="@drawable/event_medical"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent" />
 
@@ -43,7 +46,7 @@
             android:text="אירוע רפואי"
             android:textColor="@android:color/black"
             android:textStyle="bold"
-            android:textSize="16sp"
+            android:textSize="18sp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@id/event_picture"
             app:layout_constraintTop_toTopOf="@id/event_picture" />
@@ -72,14 +75,15 @@
             app:layout_constraintEnd_toStartOf="@id/event_picture"
             app:layout_constraintTop_toBottomOf="@id/event_date">
 
-            <ImageView
-                android:id="@+id/volunteer_image"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_marginStart="4dp"
-                android:background="@drawable/circle_image"
-                android:scaleType="centerCrop"
-                android:src="@drawable/newuserpic" />
+            <TextView
+                android:id="@+id/volunteer_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="מתנדב:"
+                android:textColor="@android:color/black"
+                android:textStyle="bold"
+                android:textSize="12sp"
+                android:layout_marginEnd="4dp" />
 
             <TextView
                 android:id="@+id/volunteer_name"
@@ -90,14 +94,13 @@
                 android:textColor="@android:color/black"
                 android:textSize="14sp" />
 
-            <TextView
-                android:id="@+id/volunteer_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="מתנדב:"
-                android:textColor="@android:color/black"
-                android:textStyle="bold"
-                android:textSize="14sp" />
+            <ImageView
+                android:id="@+id/volunteer_image"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:background="@drawable/circle_image"
+                android:scaleType="centerCrop"
+                android:src="@drawable/newuserpic" />
         </LinearLayout>
 
         <LinearLayout
@@ -136,7 +139,8 @@
             android:textColor="@android:color/white"
             android:textSize="14sp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/rating_container" />
+            app:layout_constraintTop_toBottomOf="@id/rating_container"
+            app:layout_constraintBottom_toBottomOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
## Summary
- fully redesign event card item layout
  - enforce RTL layout direction
  - place image on the right
  - reorder volunteer info
  - adjust text sizes and margins
  - anchor button to bottom of card

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684abe9e9c148330937b3086577f0d97