### PR TITLE
Fix missing style for ShapeableImageView

### DIFF
--- a/app/src/main/res/values/shape_appearance.xml
+++ b/app/src/main/res/values/shape_appearance.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Circle appearance used for ShapeableImageView -->
+    <style name="ShapeAppearance.Material.Circle" parent="ShapeAppearance.Material3.SmallComponent">
+        <item name="cornerSize">50%</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Summary
- add a `ShapeAppearance.Material.Circle` style so event.xml can build

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684ad140ea008330b0db8ac4da2fe3d2