### PR TITLE
Enhance event card details

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/activities/EventsAdapter.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/activities/EventsAdapter.java
@@ -13,11 +13,11 @@ import android.widget.RatingBar;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import java.text.SimpleDateFormat;
+import android.text.format.DateUtils;
 import java.util.ArrayList;
-import java.util.Locale;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Date;
 
 import com.bumptech.glide.Glide;
 
@@ -85,8 +85,8 @@ public class EventsAdapter extends ArrayAdapter<Event> {
             whatHappened.setText("אירוע " + event.getEventType());
 
             if (event.getEventTimeStarted() != null) {
-                SimpleDateFormat sdf = new SimpleDateFormat("dd MMM yyyy, HH:mm", Locale.ENGLISH);
-                date.setText(sdf.format(event.getEventTimeStarted().toDate()));
+                Date d = event.getEventTimeStarted().toDate();
+                date.setText(getTimeAgo(d));
             } else {
                 date.setText("תאריך לא ידוע");
             }
@@ -154,5 +154,16 @@ public class EventsAdapter extends ArrayAdapter<Event> {
         });
 
         return rootView;
+    }
+
+    private String getTimeAgo(Date date) {
+        long now = System.currentTimeMillis();
+        if (date == null) return "";
+        CharSequence ago = DateUtils.getRelativeTimeSpanString(
+                date.getTime(),
+                now,
+                DateUtils.MINUTE_IN_MILLIS,
+                DateUtils.FORMAT_SHOW_DATE);
+        return ago != null ? ago.toString() : "";
     }
 }

--- a/app/src/main/res/drawable/volunteer_label_bg.xml
+++ b/app/src/main/res/drawable/volunteer_label_bg.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/green_dark" />
+    <corners android:radius="8dp" />
+</shape>

--- a/app/src/main/res/layout/event.xml
+++ b/app/src/main/res/layout/event.xml
@@ -98,6 +98,21 @@
             app:strokeColor="?attr/colorPrimary"
             app:strokeWidth="1dp" />
 
+        <!-- תגית המציינת שהמשתמש הינו מתנדב -->
+        <TextView
+            android:id="@+id/volunteer_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:paddingHorizontal="6dp"
+            android:paddingVertical="2dp"
+            android:text="מתנדב"
+            android:textAppearance="@style/TextAppearance.Material3.LabelSmall"
+            android:textColor="@android:color/white"
+            android:background="@drawable/volunteer_label_bg"
+            app:layout_constraintStart_toEndOf="@+id/creator_image"
+            app:layout_constraintTop_toTopOf="@+id/creator_image"/>
+
         <!-- שם מתנדב - ימינה מהתמונה -->
         <TextView
             android:id="@+id/creator_name"
@@ -107,7 +122,7 @@
             android:text="עומר גמליאל"
             android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
             android:textStyle="bold"
-            app:layout_constraintTop_toTopOf="@+id/creator_image"
+            app:layout_constraintTop_toBottomOf="@id/volunteer_label"
             app:layout_constraintBottom_toTopOf="@+id/event_rating"
             app:layout_constraintStart_toEndOf="@+id/creator_image"
             app:layout_constraintVertical_chainStyle="packed" />
@@ -122,6 +137,7 @@
             android:numStars="5"
             android:rating="5"
             android:stepSize="0.5"
+            android:progressDrawable="@drawable/custom_rating_bar"
             app:layout_constraintTop_toBottomOf="@+id/creator_name"
             app:layout_constraintStart_toStartOf="@+id/creator_name"
             app:layout_constraintBottom_toBottomOf="@+id/creator_image"


### PR DESCRIPTION
## Summary
- add volunteer label background
- show volunteer tag and custom colored rating bar in event item
- display relative event time based on device locale

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684ad7491f608330ba2f23f2f0767c1b