### PR TITLE
Improve education card view

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/activities/EducationActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/activities/EducationActivity.java
@@ -6,10 +6,14 @@ import android.widget.ListView;
 import android.widget.Toast;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import co.median.android.a2025_theangels_new.R;
 import co.median.android.a2025_theangels_new.models.Training;
+import co.median.android.a2025_theangels_new.models.EventType;
 import co.median.android.a2025_theangels_new.services.TrainingDataManager;
+import co.median.android.a2025_theangels_new.services.EventTypeDataManager;
 
 public class EducationActivity extends BaseActivity {
 
@@ -18,6 +22,8 @@ public class EducationActivity extends BaseActivity {
     private ListView trainingsListView;
     private ArrayList<Training> trainings;
     private Trainingadapter adapter;
+    private Map<String, String> typeImages = new HashMap<>();
+    private Map<String, String> typeColors = new HashMap<>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -34,7 +40,30 @@ public class EducationActivity extends BaseActivity {
         trainingsListView.setAdapter(adapter);
         Log.d(TAG, "ListView and adapter initialized");
 
-        loadTrainingsFromFirestore();
+        loadEventTypes();
+    }
+
+    private void loadEventTypes() {
+        EventTypeDataManager.getAllEventTypes(new EventTypeDataManager.EventTypeCallback() {
+            @Override
+            public void onEventTypesLoaded(ArrayList<EventType> types) {
+                for (EventType type : types) {
+                    typeImages.put(type.getTypeName(), type.getTypeImageURL());
+                    if (type.getTypeColor() != null) {
+                        typeColors.put(type.getTypeName(), type.getTypeColor());
+                    }
+                }
+                adapter.setTypeImages(typeImages);
+                adapter.setTypeColors(typeColors);
+                loadTrainingsFromFirestore();
+            }
+
+            @Override
+            public void onError(Exception e) {
+                Log.e(TAG, "Error loading event types", e);
+                loadTrainingsFromFirestore();
+            }
+        });
     }
 
     private void loadTrainingsFromFirestore() {

--- a/app/src/main/java/co/median/android/a2025_theangels_new/activities/Trainingadapter.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/activities/Trainingadapter.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.graphics.Color;
 
 import androidx.annotation.Nullable;
 
@@ -22,11 +23,21 @@ public class Trainingadapter extends ArrayAdapter<Training> {
 
     private Context context;
     private ArrayList<Training> trainingsList;
+    private java.util.Map<String, String> typeImages;
+    private java.util.Map<String, String> typeColors;
 
     public Trainingadapter(Context context, int resource, ArrayList<Training> trainingsList) {
         super(context, resource, trainingsList);
         this.context = context;
         this.trainingsList = trainingsList;
+    }
+
+    public void setTypeImages(java.util.Map<String, String> typeImages) {
+        this.typeImages = typeImages;
+    }
+
+    public void setTypeColors(java.util.Map<String, String> typeColors) {
+        this.typeColors = typeColors;
     }
 
     @Override
@@ -50,10 +61,19 @@ public class Trainingadapter extends ArrayAdapter<Training> {
         Training training = getItem(position);
 
         TextView title = rootView.findViewById(R.id.training_title);
+        TextView typeLabel = rootView.findViewById(R.id.training_type_label);
         ImageView picture = rootView.findViewById(R.id.training_picture);
 
         if (training != null) {
             title.setText(training.getEduTitle());
+            typeLabel.setText(training.getEduType());
+
+            if (typeColors != null && typeColors.containsKey(training.getEduType())) {
+                try {
+                    int color = Color.parseColor(typeColors.get(training.getEduType()));
+                    typeLabel.setBackgroundColor(color);
+                } catch (Exception ignored) {}
+            }
 
             // Load image from URL using Glide. Fallback to placeholder if needed
             Glide.with(context)

--- a/app/src/main/java/co/median/android/a2025_theangels_new/models/EventType.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/models/EventType.java
@@ -6,6 +6,7 @@ public class EventType {
 
     private String typeName;
     private String typeImageURL;
+    private String typeColor;
     private List<String> questions;
 
     public EventType() {
@@ -26,6 +27,14 @@ public class EventType {
 
     public void setTypeImageURL(String typeImageURL) {
         this.typeImageURL = typeImageURL;
+    }
+
+    public String getTypeColor() {
+        return typeColor;
+    }
+
+    public void setTypeColor(String typeColor) {
+        this.typeColor = typeColor;
     }
 
     public List<String> getQuestions() {

--- a/app/src/main/res/layout/training_item.xml
+++ b/app/src/main/res/layout/training_item.xml
@@ -1,41 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
-    app:cardCornerRadius="12dp"
+    app:cardCornerRadius="16dp"
     app:cardElevation="6dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp">
+        android:padding="16dp"
+        android:layoutDirection="rtl">
 
         <ImageView
             android:id="@+id/training_picture"
-            android:layout_width="80dp"
-            android:layout_height="80dp"
+            android:layout_width="72dp"
+            android:layout_height="72dp"
             android:scaleType="centerCrop"
             android:src="@drawable/training1"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent" />
+
+        <ImageView
+            android:id="@+id/arrow_icon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_arrow_left"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+        <TextView
+            android:id="@+id/training_type_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="6dp"
+            android:paddingVertical="2dp"
+            android:text="סוג הדרכה"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            android:textColor="@android:color/white"
+            android:background="@drawable/event_label_bg"
+            app:layout_constraintStart_toEndOf="@id/arrow_icon"
+            app:layout_constraintEnd_toStartOf="@id/training_picture"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/training_title"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="איך להפעיל דפיברילטור?"
-            android:textSize="18sp"
+            android:layout_marginTop="4dp"
+            android:text="כותרת הדרכה"
+            android:textSize="16sp"
             android:textStyle="bold"
-            android:layout_marginEnd="8dp"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/training_picture" />
-
-        
+            app:layout_constraintStart_toStartOf="@id/training_type_label"
+            app:layout_constraintEnd_toStartOf="@id/training_picture"
+            app:layout_constraintTop_toBottomOf="@id/training_type_label" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.cardview.widget.CardView>
-
+</com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- enhance EventType model to store `typeColor`
- show training type and arrow on card view
- map event type colors in EducationActivity
- style training list items similar to event cards

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684ade7c4d488330bae6cdf05b0286a5