### PR TITLE
Fix Glide usage to avoid crash when Activity is destroyed

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/activities/EventsAdapter.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/activities/EventsAdapter.java
@@ -107,7 +107,7 @@ public class EventsAdapter extends ArrayAdapter<Event> {
                     if (info != null) {
                         volunteerName.setText(info.getFirstName() + " " + info.getLastName());
                         if (info.getImageURL() != null && !info.getImageURL().isEmpty()) {
-                            Glide.with(context)
+                            Glide.with(context.getApplicationContext())
                                     .load(info.getImageURL())
                                     .placeholder(R.drawable.newuserpic)
                                     .circleCrop()
@@ -120,7 +120,7 @@ public class EventsAdapter extends ArrayAdapter<Event> {
                             volunteerCache.put(uid, info);
                             volunteerName.setText(info.getFirstName() + " " + info.getLastName());
                             if (info.getImageURL() != null && !info.getImageURL().isEmpty()) {
-                                Glide.with(context)
+                                Glide.with(context.getApplicationContext())
                                         .load(info.getImageURL())
                                         .placeholder(R.drawable.newuserpic)
                                         .circleCrop()


### PR DESCRIPTION
## Summary
- prevent Glide from using destroyed Activity context in `EventsAdapter`

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ae6d0875c83309fe0978e850f9162