### PR TITLE
Link event details screen to Firestore

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/activities/EventDetailsActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/activities/EventDetailsActivity.java
@@ -8,17 +8,25 @@ import android.location.Address;
 import android.location.Geocoder;
 import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.RatingBar;
 import android.widget.TextView;
 
 import androidx.fragment.app.FragmentTransaction;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import co.median.android.a2025_theangels_new.R;
 import co.median.android.a2025_theangels_new.fragments.StaticMapFragment;
+import co.median.android.a2025_theangels_new.models.Event;
+import co.median.android.a2025_theangels_new.models.UserBasicInfo;
+import co.median.android.a2025_theangels_new.services.EventDataManager;
+import co.median.android.a2025_theangels_new.services.UserDataManager;
 import com.bumptech.glide.Glide;
 
 // =======================================
@@ -37,9 +45,7 @@ public class EventDetailsActivity extends BaseActivity {
         showBottomBar(false);
 
         String eventType = getIntent().getStringExtra("eventType");
-        String eventStatus = getIntent().getStringExtra("eventStatus");
         String handleBy = getIntent().getStringExtra("eventHandleBy");
-        long timeStartedSeconds = getIntent().getLongExtra("eventTimeStarted", 0);
         int rating = getIntent().getIntExtra("eventRating", 0);
         double eventLat = getIntent().getDoubleExtra("lat", 0);
         double eventLng = getIntent().getDoubleExtra("lng", 0);
@@ -48,8 +54,15 @@ public class EventDetailsActivity extends BaseActivity {
         TextView tvType = findViewById(R.id.event_type_text);
         Button btnNavigate = findViewById(R.id.btnNavigate);
         TextView tvVolunteer = findViewById(R.id.volunteer_name);
+        ImageView volunteerImage = findViewById(R.id.volunteer_image);
         RatingBar ratingBar = findViewById(R.id.ratingBarDetails);
         ImageView ivType = findViewById(R.id.event_type_image);
+        LinearLayout findingsContainer = findViewById(R.id.findings_container);
+        TextView durationText = findViewById(R.id.duration_text);
+        TextView summaryStart = findViewById(R.id.summary_start_time);
+        TextView summaryVolunteer = findViewById(R.id.summary_volunteer);
+        TextView summaryEnd = findViewById(R.id.summary_end_time);
+        TextView closeReasonText = findViewById(R.id.close_reason_text);
 
         if (tvType != null && eventType != null) {
             tvType.setText(eventType);
@@ -63,6 +76,67 @@ public class EventDetailsActivity extends BaseActivity {
         if (ratingBar != null) {
             ratingBar.setRating(rating);
         }
+
+        EventDataManager.getEventByType(eventType, new EventDataManager.SingleEventCallback() {
+            @Override
+            public void onEventLoaded(Event event) {
+                if (event == null) return;
+
+                Map<String, Object> form = event.getEventForm();
+                if (form != null && findingsContainer != null) {
+                    findingsContainer.removeAllViews();
+                    for (Map.Entry<String, Object> entry : form.entrySet()) {
+                        boolean value = entry.getValue() instanceof Boolean && (Boolean) entry.getValue();
+                        TextView tv = new TextView(EventDetailsActivity.this);
+                        tv.setText((value ? "\u2714 " : "\u2716 ") + entry.getKey());
+                        int color = getResources().getColor(value ? android.R.color.holo_green_dark : android.R.color.holo_red_dark);
+                        tv.setTextColor(color);
+                        findingsContainer.addView(tv);
+                    }
+                }
+
+                if (event.getEventTimeStarted() != null && event.getEventTimeEnded() != null && durationText != null) {
+                    long diff = event.getEventTimeEnded().toDate().getTime() - event.getEventTimeStarted().toDate().getTime();
+                    long minutes = TimeUnit.MILLISECONDS.toMinutes(diff);
+                    durationText.setText("\u23F3 האירוע התרחש במשך " + minutes + " דקות");
+
+                    SimpleDateFormat sdf = new SimpleDateFormat("HH:mm", Locale.getDefault());
+                    if (summaryStart != null)
+                        summaryStart.setText(sdf.format(event.getEventTimeStarted().toDate()) + " - האירוע נפתח על ידי המשתמש.");
+                    if (summaryEnd != null)
+                        summaryEnd.setText(sdf.format(event.getEventTimeEnded().toDate()) + " - האירוע הסתיים.");
+                }
+
+                if (closeReasonText != null && event.getEventCloseReason() != null) {
+                    closeReasonText.setText(event.getEventCloseReason());
+                }
+
+                ratingBar.setRating(event.getEventRating());
+
+                String volunteerUid = event.getEventHandleBy();
+                if (volunteerUid != null && !volunteerUid.isEmpty()) {
+                    UserDataManager.loadBasicUserInfo(volunteerUid, info -> {
+                        if (info != null) {
+                            String name = info.getFirstName() + " " + info.getLastName();
+                            if (tvVolunteer != null) tvVolunteer.setText(name);
+                            if (summaryVolunteer != null) summaryVolunteer.setText("המתנדב " + name + " שויך לאירוע");
+                            if (volunteerImage != null && info.getImageURL() != null && !info.getImageURL().isEmpty()) {
+                                Glide.with(EventDetailsActivity.this)
+                                        .load(info.getImageURL())
+                                        .placeholder(R.drawable.newuserpic)
+                                        .circleCrop()
+                                        .into(volunteerImage);
+                            }
+                        }
+                    });
+                }
+            }
+
+            @Override
+            public void onError(Exception e) {
+                // handle error if needed
+            }
+        });
 
         if (eventLat != 0 && eventLng != 0) {
             Geocoder geocoder = new Geocoder(this, Locale.getDefault());

--- a/app/src/main/java/co/median/android/a2025_theangels_new/services/EventDataManager.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/services/EventDataManager.java
@@ -88,4 +88,25 @@ public class EventDataManager {
                     callback.onError(e);
                 });
     }
+
+    public interface SingleEventCallback {
+        void onEventLoaded(Event event);
+        void onError(Exception e);
+    }
+
+    public static void getEventByType(@NonNull String eventType, SingleEventCallback callback) {
+        FirebaseFirestore.getInstance().collection("events")
+                .whereEqualTo("eventType", eventType)
+                .limit(1)
+                .get()
+                .addOnSuccessListener(queryDocumentSnapshots -> {
+                    Event event = null;
+                    for (DocumentSnapshot doc : queryDocumentSnapshots.getDocuments()) {
+                        event = doc.toObject(Event.class);
+                        break;
+                    }
+                    callback.onEventLoaded(event);
+                })
+                .addOnFailureListener(callback::onError);
+    }
 }

--- a/app/src/main/res/layout/activity_event_details.xml
+++ b/app/src/main/res/layout/activity_event_details.xml
@@ -92,162 +92,167 @@
                     android:textColor="@android:color/white"/>
             </LinearLayout>
 
-            <LinearLayout
+            <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="12dp"
-                android:background="@color/light_gray"
-                android:orientation="vertical"
-                android:layout_marginBottom="8dp">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/findings_title"
-                    android:textSize="18sp"
-                    android:textStyle="bold"
-                    android:textColor="@android:color/black"
-                    android:layout_marginBottom="6dp"/>
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/finding_safe"
-                    android:textSize="16sp"
-                    android:textColor="@android:color/holo_green_dark"
-                    android:layout_marginBottom="4dp"/>
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/finding_pulse"
-                    android:textSize="16sp"
-                    android:textColor="@android:color/holo_green_dark"
-                    android:layout_marginBottom="4dp"/>
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/finding_breathing"
-                    android:textSize="16sp"
-                    android:textColor="@android:color/holo_red_dark"
-                    android:layout_marginBottom="4dp"/>
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/finding_bleeding"
-                    android:textSize="16sp"
-                    android:textColor="@android:color/holo_red_dark"
-                    android:layout_marginBottom="4dp"/>
-            </LinearLayout>
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/event_duration"
-                android:textSize="16sp"
-                android:textColor="@android:color/black"
-                android:padding="12dp"
-                android:background="@color/light_gray"
-                android:layout_marginBottom="8dp"/>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="12dp"
-                android:background="@color/light_gray"
-                android:orientation="vertical"
-                android:layout_marginBottom="8dp">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/event_summary"
-                    android:textSize="18sp"
-                    android:textStyle="bold"
-                    android:textColor="@android:color/black"
-                    android:layout_marginBottom="6dp"/>
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/summary_1"
-                    android:textSize="16sp"
-                    android:textColor="@android:color/black"/>
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/summary_2"
-                    android:textSize="16sp"
-                    android:textColor="@android:color/black"/>
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/summary_3"
-                    android:textSize="16sp"
-                    android:textColor="@android:color/black"/>
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/summary_4"
-                    android:textSize="16sp"
-                    android:textColor="@android:color/black"/>
-            </LinearLayout>
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/summary_footer"
-                android:textSize="16sp"
-                android:textColor="@android:color/black"
-                android:padding="12dp"
-                android:background="@color/light_gray"
-                android:layout_marginBottom="8dp"/>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="12dp"
-                android:background="@color/light_gray"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
-
-                <ImageView
-                    android:layout_width="60dp"
-                    android:layout_height="60dp"
-                    android:src="@drawable/event_angel"
-                    android:scaleType="centerCrop"
-                    android:layout_marginEnd="12dp" />
+                android:layout_marginBottom="8dp"
+                app:cardBackgroundColor="@color/light_gray"
+                app:cardCornerRadius="8dp"
+                app:cardElevation="2dp">
 
                 <LinearLayout
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:padding="12dp">
 
                     <TextView
-                        android:id="@+id/volunteer_name"
-                        android:layout_width="wrap_content"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:textColor="@android:color/black"
-                        android:text="@string/volunteer_name"
+                        android:text="@string/findings_title"
                         android:textSize="18sp"
-                        android:textStyle="bold"/>
+                        android:textStyle="bold"
+                        android:textColor="@android:color/black"
+                        android:layout_marginBottom="6dp"/>
 
-                    <RatingBar
-                        android:id="@+id/ratingBarDetails"
+                    <LinearLayout
+                        android:id="@+id/findings_container"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
+
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                app:cardBackgroundColor="@color/light_gray"
+                app:cardCornerRadius="8dp"
+                app:cardElevation="2dp">
+
+                <TextView
+                    android:id="@+id/duration_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textSize="16sp"
+                    android:textColor="@android:color/black"
+                    android:padding="12dp" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                app:cardBackgroundColor="@color/light_gray"
+                app:cardCornerRadius="8dp"
+                app:cardElevation="2dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="12dp">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/event_summary"
+                        android:textSize="18sp"
+                        android:textStyle="bold"
+                        android:textColor="@android:color/black"
+                        android:layout_marginBottom="6dp"/>
+
+                    <TextView
+                        android:id="@+id/summary_start_time"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:numStars="5"
-                        android:stepSize="1"
-                        android:rating="4"
-                        android:isIndicator="true"
-                        style="?android:attr/ratingBarStyleSmall"/>
+                        android:textSize="16sp"
+                        android:textColor="@android:color/black"/>
+
+                    <TextView
+                        android:id="@+id/summary_volunteer"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="16sp"
+                        android:textColor="@android:color/black"/>
+
+                    <TextView
+                        android:id="@+id/summary_end_time"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="16sp"
+                        android:textColor="@android:color/black"/>
                 </LinearLayout>
-            </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                app:cardBackgroundColor="@color/light_gray"
+                app:cardCornerRadius="8dp"
+                app:cardElevation="2dp">
+
+                <TextView
+                    android:id="@+id/close_reason_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textSize="16sp"
+                    android:textColor="@android:color/black"
+                    android:padding="12dp" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                app:cardBackgroundColor="@color/light_gray"
+                app:cardCornerRadius="8dp"
+                app:cardElevation="2dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:padding="12dp"
+                    android:gravity="center_vertical">
+
+                    <ImageView
+                        android:id="@+id/volunteer_image"
+                        android:layout_width="60dp"
+                        android:layout_height="60dp"
+                        android:src="@drawable/event_angel"
+                        android:scaleType="centerCrop"
+                        android:layout_marginEnd="12dp" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/volunteer_name"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="@android:color/black"
+                            android:text="@string/volunteer_name"
+                            android:textSize="18sp"
+                            android:textStyle="bold"/>
+
+                        <RatingBar
+                            android:id="@+id/ratingBarDetails"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:numStars="5"
+                            android:stepSize="1"
+                            android:rating="4"
+                            android:isIndicator="true"
+                            style="?android:attr/ratingBarStyleSmall"/>
+                    </LinearLayout>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
         </LinearLayout>
     </ScrollView>
 </RelativeLayout>


### PR DESCRIPTION
## Summary
- connect EventDetailsActivity to Firestore using a new query
- fetch volunteer info and event details from Firebase
- display dynamic findings, duration, summary and close reason
- upgrade event details layout with MaterialCardView containers

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684af10d6c588330bbd2d91d3d179479