### PR TITLE
Add real-time address display under home map

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/activities/HomeActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/activities/HomeActivity.java
@@ -40,7 +40,7 @@ import co.median.android.a2025_theangels_new.activities.RecentEventsAdapter;
 // =======================================
 // HomeActivity - Displays the home screen and handles location permission logic
 // =======================================
-public class HomeActivity extends BaseActivity {
+public class HomeActivity extends BaseActivity implements MapFragment.OnAddressChangeListener {
 
     // =======================================
     // VARIABLES
@@ -52,6 +52,7 @@ public class HomeActivity extends BaseActivity {
     private LinearLayout volDashboard;
     private TextView tvEventsCount, tvAvgRating;
     private FrameLayout mapContainer;
+    private TextView tvCurrentAddress;
     private LinearLayout recentEventsContainer;
     private RecentEventsAdapter recentEventsAdapter;
     private ArrayList<Event> recentEvents = new ArrayList<>();
@@ -76,6 +77,7 @@ public class HomeActivity extends BaseActivity {
         tvEventsCount = findViewById(R.id.tv_events_count);
         tvAvgRating = findViewById(R.id.tv_avg_rating);
         mapContainer = findViewById(R.id.map_container);
+        tvCurrentAddress = findViewById(R.id.tv_current_address);
         recentEventsContainer = findViewById(R.id.recent_events_container);
         recentEventsAdapter = new RecentEventsAdapter(this, R.layout.item_recent_event, recentEvents);
 
@@ -125,7 +127,9 @@ public class HomeActivity extends BaseActivity {
     // =======================================
     private void loadMapFragment() {
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
-        transaction.replace(R.id.map_container, new MapFragment());
+        MapFragment fragment = new MapFragment();
+        fragment.setAddressChangeListener(this);
+        transaction.replace(R.id.map_container, fragment);
         transaction.commit();
     }
 
@@ -266,5 +270,12 @@ public class HomeActivity extends BaseActivity {
     @Override
     protected int getLayoutResourceId() {
         return R.layout.activity_home;
+    }
+
+    @Override
+    public void onAddressChanged(String address) {
+        if (tvCurrentAddress != null) {
+            tvCurrentAddress.setText(address);
+        }
     }
 }

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -311,6 +311,18 @@
             android:layout_height="250dp"
             android:layout_marginTop="2dp"
             android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/tv_current_address"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:background="@color/light_gray"
+            android:gravity="center"
+            android:padding="8dp"
+            android:text="@string/retrieving_address"
+            android:textColor="@color/black"
+            android:textSize="16sp" />
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,7 @@
     <string name="address_not_found">הכתובת לא נמצאה</string>
     <string name="address_lookup_error">שגיאה בחיפוש כתובת</string>
     <string name="location_updated">המיקום עודכן</string>
+    <string name="retrieving_address">טוען כתובת...</string>
 
 
 


### PR DESCRIPTION
## Summary
- show current address below the map on the home screen
- send address updates from `MapFragment` via new listener interface
- update `HomeActivity` to handle address changes
- add address text view to layout and strings

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684af731aeb08330b77b5c9f5e665580