### PR TITLE
Add Hebrew Javadoc

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/MyApplication.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/MyApplication.java
@@ -5,7 +5,15 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.FirebaseFirestoreSettings;
 
+/**
+ * מחלקת היישום הראשית של האפליקציה.
+ * כאן מתבצעת אתחול Firebase והגדרות בסיסיות בעת הפעלת האפליקציה.
+ */
 public class MyApplication extends Application {
+    /**
+     * מופעלת עם פתיחת האפליקציה ומבצעת אתחול של Firebase.
+     * בנוסף מוגדרת שמירת נתונים מקומית כדי לאפשר עבודה גם ללא רשת.
+     */
     @Override
     public void onCreate() {
         super.onCreate();

--- a/app/src/main/java/co/median/android/a2025_theangels_new/adapters/OnboardingAdapter.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/adapters/OnboardingAdapter.java
@@ -10,10 +10,10 @@ import java.util.List;
 
 import co.median.android.a2025_theangels_new.activities.OnboardingFragment;
 
-// =======================================
-// OnboardingAdapter - Adapter for onboarding ViewPager2
-// Creates fragments for each onboarding image
-// =======================================
+/**
+ * מתאם המציג את מסכי ההדרכה הראשוניים באפליקציה.
+ * לכל עמוד מוצגת תמונה אחרת מתוך רשימת התמונות שהתקבלה.
+ */
 public class OnboardingAdapter extends FragmentStateAdapter {
 
     // =======================================
@@ -21,26 +21,34 @@ public class OnboardingAdapter extends FragmentStateAdapter {
     // =======================================
     private final List<Integer> images;
 
-    // =======================================
-    // Constructor - Receives activity and list of drawable resources
-    // =======================================
+    /**
+     * יוצר את המתאם עם הפעילות והרשימה של התמונות להצגה.
+     *
+     * @param fragmentActivity הפעילות שמחזיקה את ViewPager2
+     * @param images           רשימת מזהי תמונה שמוצגים בעמודי ההדרכה
+     */
     public OnboardingAdapter(@NonNull FragmentActivity fragmentActivity, List<Integer> images) {
         super(fragmentActivity);
         this.images = images;
     }
 
-    // =======================================
-    // createFragment - Returns a new OnboardingFragment with the image for the current position
-    // =======================================
+    /**
+     * יוצר עמוד חדש של ההדרכה בהתאם למיקום המבוקש.
+     *
+     * @param position המיקום הנוכחי בעמודים
+     * @return פרגמנט שמציג את התמונה המתאימה
+     */
     @NonNull
     @Override
     public Fragment createFragment(int position) {
         return OnboardingFragment.newInstance(images.get(position));
     }
 
-    // =======================================
-    // getItemCount - Returns number of onboarding pages
-    // =======================================
+    /**
+     * מחזיר את מספר עמודי ההדרכה שקיימים.
+     *
+     * @return כמות העמודים הכוללת
+     */
     @Override
     public int getItemCount() {
         return images.size();

--- a/app/src/main/java/co/median/android/a2025_theangels_new/fragments/MapFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/fragments/MapFragment.java
@@ -45,9 +45,10 @@ import com.google.android.gms.maps.model.MarkerOptions;
 
 import co.median.android.a2025_theangels_new.R;
 
-// =======================================
-// MapFragment - Displays Google Map with current user location
-// =======================================
+/**
+ * פרגמנט המציג מפה ומאתר את מיקומו הנוכחי של המשתמש.
+ * אם אין הרשאה למיקום, מוצג מסך חלופי המבקש גישה.
+ */
 public class MapFragment extends Fragment implements OnMapReadyCallback {
 
     // =======================================
@@ -92,9 +93,13 @@ public class MapFragment extends Fragment implements OnMapReadyCallback {
         void onAddressChanged(String address);
     }
 
-    // =======================================
-    // onViewCreated - Initializes map and views
-    // =======================================
+    /**
+     * מופעל לאחר יצירת תצוגת הפרגמנט ומאתחל את המפה והרכיבים השונים.
+     * כאן גם נרשמת בקשת ההרשאה למיקום במידת הצורך.
+     *
+     * @param view               התצוגה של הפרגמנט
+     * @param savedInstanceState מצב שמור אם קיים
+     */
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
@@ -128,9 +133,12 @@ public class MapFragment extends Fragment implements OnMapReadyCallback {
         }
     }
 
-    // =======================================
-    // onMapReady - Called when map is ready to use
-    // =======================================
+    /**
+     * נקרא כאשר המפה נטענה ומוכנה לשימוש.
+     * כאן מוחלים עיצוב מותאם ונבדקות הרשאות מיקום.
+     *
+     * @param googleMap מופע המפה שהתקבל
+     */
     @Override
     public void onMapReady(@NonNull GoogleMap googleMap) {
         mMap = googleMap;
@@ -165,9 +173,10 @@ public class MapFragment extends Fragment implements OnMapReadyCallback {
         }
     }
 
-    // =======================================
-    // enableUserLocation - Enables MyLocation and requests user position
-    // =======================================
+    /**
+     * מפעיל את הצגת המיקום על המפה ומתחיל בקבלת עדכוני מיקום.
+     * נקרא לאחר קבלת הרשאת מיקום מהמשתמש.
+     */
     private void enableUserLocation() {
         if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.ACCESS_FINE_LOCATION)
                 == PackageManager.PERMISSION_GRANTED) {
@@ -181,9 +190,10 @@ public class MapFragment extends Fragment implements OnMapReadyCallback {
         }
     }
 
-    // =======================================
-    // showPlaceholder - Shows fallback UI when location permission is denied
-    // =======================================
+    /**
+     * מציג שכבת חלופה במקרה שהרשאת המיקום נדחתה על ידי המשתמש.
+     * בנוסף מעדכן את המאזין בכתובת כללית שאין מיקום.
+     */
     private void showPlaceholder() {
         View mapView = requireView().findViewById(R.id.map);
         mapView.setVisibility(View.GONE);
@@ -193,9 +203,10 @@ public class MapFragment extends Fragment implements OnMapReadyCallback {
         }
     }
 
-    // =======================================
-    // getUserLocation - Requests the user's current location
-    // =======================================
+    /**
+     * מבקש מהמכשיר את מיקומו האחרון הזמין ומעדכן את המפה בהתאם.
+     * במקרה של כישלון יירשם בלוג אך לא תבוצע פעולה נוספת.
+     */
     private void getUserLocation() {
         if (ActivityCompat.checkSelfPermission(requireContext(), Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
             return;
@@ -209,6 +220,9 @@ public class MapFragment extends Fragment implements OnMapReadyCallback {
                 .addOnFailureListener(Throwable::printStackTrace);
     }
 
+    /**
+     * מתחיל קבלת עדכוני מיקום שוטפים מהמכשיר ומעדכן מיד את המפה.
+     */
     private void startLocationUpdates() {
         if (ActivityCompat.checkSelfPermission(requireContext(), Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
             return;
@@ -217,19 +231,28 @@ public class MapFragment extends Fragment implements OnMapReadyCallback {
         getUserLocation();
     }
 
+    /**
+     * מפסיק את קבלת עדכוני המיקום כאשר הפרגמנט נעצר.
+     */
     private void stopLocationUpdates() {
         fusedLocationClient.removeLocationUpdates(locationCallback);
     }
 
+    /**
+     * כאשר הפרגמנט מפסיק לפעול מפסיקים גם את עדכוני המיקום כדי לחסוך משאבים.
+     */
     @Override
     public void onStop() {
         super.onStop();
         stopLocationUpdates();
     }
 
-    // =======================================
-    // updateMapLocation - Centers camera and adds marker at user location
-    // =======================================
+    /**
+     * מעדכן את מיקום המשתמש על המפה ומרכז את התצוגה סביבו.
+     * בנוסף מוצב סמן מותאם אישית ומדווח על הכתובת למאזין.
+     *
+     * @param location מיקום משתמש שנמצא
+     */
     private void updateMapLocation(Location location) {
         LatLng userLatLng = new LatLng(location.getLatitude(), location.getLongitude());
 
@@ -253,9 +276,14 @@ public class MapFragment extends Fragment implements OnMapReadyCallback {
         }
     }
 
-    // =======================================
-    // resizeMarker - Resizes custom marker drawable
-    // =======================================
+    /**
+     * משנה את גודל האייקון של הסמן כדי שיוצג במפה בצורה נכונה.
+     *
+     * @param drawableRes מזהה המשאב של האייקון
+     * @param width       רוחב נדרש בפיקסלים
+     * @param height      גובה נדרש בפיקסלים
+     * @return אובייקט ביטמאפ לאחר שינוי גודל
+     */
     private BitmapDescriptor resizeMarker(int drawableRes, int width, int height) {
         Drawable drawable = ContextCompat.getDrawable(requireContext(), drawableRes);
         if (drawable == null) return null;
@@ -268,6 +296,13 @@ public class MapFragment extends Fragment implements OnMapReadyCallback {
         return BitmapDescriptorFactory.fromBitmap(bitmap);
     }
 
+    /**
+     * ממיר את נקודת המיקום לכתובת קריאה למשתמש.
+     * במקרה ואין כתובת זמינה מוחזר טקסט כללי.
+     *
+     * @param location מיקום שממנו מחפשים כתובת
+     * @return מחרוזת כתובת תיאורית
+     */
     private String getAddressFromLocation(Location location) {
         Geocoder geocoder = new Geocoder(requireContext(), Locale.getDefault());
         try {

--- a/app/src/main/java/co/median/android/a2025_theangels_new/services/EventDataManager.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/services/EventDataManager.java
@@ -12,15 +12,35 @@ import java.util.Collections;
 
 import co.median.android.a2025_theangels_new.models.Event;
 
+/**
+ * אחראי לשליפת אירועים ממסד הנתונים של Firebase.
+ */
 public class EventDataManager {
 
     private static final String TAG = "EventDataManager";
 
+    /**
+     * ממשק לקבלת רשימת אירועים או הודעת שגיאה.
+     */
     public interface EventCallback {
+        /**
+         * נקרא עם סיום השליפה המוצלחת.
+         * @param events רשימת האירועים שהתקבלה
+         */
         void onEventsLoaded(ArrayList<Event> events);
+
+        /**
+         * נקרא במקרה של שגיאה.
+         * @param e פירוט השגיאה
+         */
         void onError(Exception e);
     }
 
+    /**
+     * טוען את כל האירועים הקיימים במסד הנתונים.
+     *
+     * @param callback יוזם התוצאה לקבלה
+     */
     public static void getAllEvents(EventCallback callback) {
         Log.d(TAG, "getAllEvents called - starting Firestore fetch");
 
@@ -53,6 +73,13 @@ public class EventDataManager {
                 });
     }
 
+    /**
+     * מביא את האירועים האחרונים שנוצרו על ידי משתמש מסוים.
+     *
+     * @param uid      מזהה המשתמש המבוקש
+     * @param limit    כמות האירועים המקסימלית להחזרה
+     * @param callback מחזיר התוצאה
+     */
     public static void getLastEventsCreatedByUser(String uid, int limit, EventCallback callback) {
         FirebaseFirestore.getInstance().collection("events")
                 .whereEqualTo("eventCreatedBy", uid)
@@ -89,11 +116,29 @@ public class EventDataManager {
                 });
     }
 
+    /**
+     * ממשק לקבלת אירוע בודד או הודעת שגיאה.
+     */
     public interface SingleEventCallback {
+        /**
+         * אירוע שנמצא נשלח לכאן.
+         * @param event האירוע שהתקבל או null אם לא נמצא
+         */
         void onEventLoaded(Event event);
+
+        /**
+         * קריאה במקרה של תקלה בשליפה.
+         * @param e פירוט השגיאה
+         */
         void onError(Exception e);
     }
 
+    /**
+     * מחפש אירוע ראשון התואם לסוג מסוים.
+     *
+     * @param eventType סוג האירוע הרצוי
+     * @param callback  יקבל את האירוע או שגיאה
+     */
     public static void getEventByType(@NonNull String eventType, SingleEventCallback callback) {
         FirebaseFirestore.getInstance().collection("events")
                 .whereEqualTo("eventType", eventType)

--- a/app/src/main/java/co/median/android/a2025_theangels_new/services/EventTypeDataManager.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/services/EventTypeDataManager.java
@@ -9,15 +9,35 @@ import java.util.ArrayList;
 
 import co.median.android.a2025_theangels_new.models.EventType;
 
+/**
+ * מנהל שליפת סוגי אירועים ממסד הנתונים של Firebase.
+ */
 public class EventTypeDataManager {
 
     private static final String TAG = "EventTypeDataManager";
 
+    /**
+     * ממשק החוזר מידע לאחר השליפה או שגיאה במקרה של כישלון.
+     */
     public interface EventTypeCallback {
+        /**
+         * נקרא כאשר הרשימה נטענה בהצלחה.
+         * @param types רשימת סוגי האירועים שהתקבלה
+         */
         void onEventTypesLoaded(ArrayList<EventType> types);
+
+        /**
+         * נקרא כאשר התרחשה שגיאה בשליפה.
+         * @param e הפרט על השגיאה
+         */
         void onError(Exception e);
     }
 
+    /**
+     * טוען את כל סוגי האירועים ממסד הנתונים של Firebase.
+     *
+     * @param callback ממשק לקבלת התוצאות או שגיאה
+     */
     public static void getAllEventTypes(EventTypeCallback callback) {
         Log.d(TAG, "getAllEventTypes called - starting Firestore fetch");
         FirebaseFirestore.getInstance().collection("eventsType")


### PR DESCRIPTION
## Summary
- document MyApplication with Hebrew Javadoc
- document onboarding adapter
- add Hebrew Javadoc to MapFragment
- document Firebase data managers (events, event types)

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684afacf212883308aa7368e8d2439f8