### PR TITLE
Fix unresolved dependency by removing Google Navigation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,6 @@ dependencies {
     implementation(libs.lottie)
     implementation(libs.konfetti.xml)
     implementation libs.google.maps.utils
-    implementation libs.google.navigation
     implementation libs.retrofit
     implementation libs.retrofit.converter.gson
     implementation(libs.okhttp)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,6 @@ glide = "4.16.0"
 mapsUtils = "3.10.0"
 retrofit = "2.9.0"
 gsonConverter = "2.9.0"
-navigation = "1.1.0-beta"
 
 
 
@@ -68,7 +67,6 @@ firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }
 google-maps-utils = { module = "com.google.maps.android:android-maps-utils", version.ref = "mapsUtils" }
-google-navigation = { module = "com.google.android.libraries.navigation:navigation", version.ref = "navigation" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "gsonConverter" }
 


### PR DESCRIPTION
## Summary
- remove inaccessible Google Navigation library from dependency catalog
- drop `libs.google.navigation` from app module

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853ecbac494833082b9d3d1c3340202