### PR TITLE
Enable Jetpack Navigation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'com.google.gms.google-services'
+    id 'androidx.navigation.safeargs'
 }
 
 android {
@@ -55,6 +56,8 @@ dependencies {
     implementation(libs.cardview)
     implementation(libs.lottie)
     implementation(libs.konfetti.xml)
+    implementation libs.androidx.navigation.fragment
+    implementation libs.androidx.navigation.ui
     implementation libs.google.maps.utils
     implementation libs.retrofit
     implementation libs.retrofit.converter.gson

--- a/build.gradle
+++ b/build.gradle
@@ -3,5 +3,6 @@ plugins {
     id 'com.android.application' version '8.9.0' apply false
     id 'com.android.library' version '8.9.0' apply false
     id 'com.google.gms.google-services' version '4.4.2' apply false
+    id 'androidx.navigation.safeargs' version '2.7.7' apply false
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ gsonConverter = "2.9.0"
 paging = "3.2.1"
 firebaseMessaging = "24.0.0"
 shimmer = "0.5.0"
+navigation = "2.7.7"
 
 
 
@@ -75,8 +76,11 @@ retrofit-converter-gson = { module = "com.squareup.retrofit2:converter-gson", ve
 androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging", version.ref = "firebaseMessaging" }
 shimmer = { group = "com.facebook.shimmer", name = "shimmer", version.ref = "shimmer" }
+androidx-navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment", version.ref = "navigation" }
+androidx-navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "navigation" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+navigation-safe-args = { id = "androidx.navigation.safeargs", version = "2.7.7" }


### PR DESCRIPTION
## Summary
- enable Safe Args plugin in project
- add Jetpack Navigation dependencies via version catalog

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853f34374f48330b0f1a75159a6fb36