### PR TITLE
Reorganize project packages

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
 
     <application
         android:allowBackup="true"
-        android:name=".MyApplication"
+        android:name=".data.MyApplication"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/icon"
@@ -31,7 +31,7 @@
             android:name="com.google.android.libraries.places.API_KEY"
             android:value="@string/google_places_key"/>
 
-        <receiver android:name=".widget.EmergencyWidget"
+        <receiver android:name=".data.widget.EmergencyWidget"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
@@ -79,13 +79,13 @@
             android:theme="@style/Theme._2025_theangels_new"/>
 
         <activity
-            android:name=".events.list.EventsActivity"
+            android:name=".ui.events.list.EventsActivity"
             android:exported="false"
             android:label="The Angels | Events"
             android:theme="@style/Theme._2025_theangels_new"/>
 
         <activity
-            android:name=".educations.EducationActivity"
+            android:name=".ui.educations.EducationActivity"
             android:exported="false"
             android:label="The Angels | Education"
             android:theme="@style/Theme._2025_theangels_new"/>
@@ -97,7 +97,7 @@
             android:theme="@style/Theme._2025_theangels_new"/>
 
         <activity
-            android:name=".events.create.NewEventActivity"
+            android:name=".ui.events.create.NewEventActivity"
             android:exported="false"
             android:label="The Angels | Report Event"
             android:theme="@style/Theme._2025_theangels_new"/>
@@ -133,31 +133,31 @@
             android:theme="@style/Theme._2025_theangels_new"/>
 
         <activity
-            android:name=".events.active.EventUserActivity"
+            android:name=".ui.events.active.EventUserActivity"
             android:exported="false"
             android:label="The Angels | User Event"
             android:theme="@style/Theme._2025_theangels_new"/>
 
         <activity
-            android:name=".events.list.EventDetailsActivity"
+            android:name=".ui.events.list.EventDetailsActivity"
             android:exported="false"
             android:label="The Angels | Event Details"
             android:theme="@style/Theme._2025_theangels_new"/>
 
         <activity
-            android:name=".educations.EducationDetailsActivity"
+            android:name=".ui.educations.EducationDetailsActivity"
             android:exported="false"
             android:label="The Angels | Lesson Details"
             android:theme="@style/Theme._2025_theangels_new"/>
 
         <activity
-            android:name=".events.active.EventVolActivity"
+            android:name=".ui.events.active.EventVolActivity"
             android:exported="false"
             android:label="The Angels | Volunteer Event"
             android:theme="@style/Theme._2025_theangels_new"/>
 
         <service
-            android:name=".notifications.MyFirebaseMessagingService"
+            android:name=".data.notifications.MyFirebaseMessagingService"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/MyApplication.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/MyApplication.java
@@ -1,4 +1,4 @@
-package co.median.android.a2025_theangels_new;
+package co.median.android.a2025_theangels_new.data;
 
 import android.app.Application;
 import com.google.firebase.FirebaseApp;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/map/LocationFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/map/LocationFragment.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.map;
+package co.median.android.a2025_theangels_new.data.map;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/map/MapFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/map/MapFragment.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.map;
+package co.median.android.a2025_theangels_new.data.map;
 
 import android.Manifest;
 import android.content.pm.PackageManager;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/map/StaticMapFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/map/StaticMapFragment.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.map;
+package co.median.android.a2025_theangels_new.data.map;
 
 import android.os.Bundle;
 import android.view.View;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/notifications/MyFirebaseMessagingService.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/notifications/MyFirebaseMessagingService.java
@@ -1,4 +1,4 @@
-package co.median.android.a2025_theangels_new.notifications;
+package co.median.android.a2025_theangels_new.data.notifications;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/widget/EmergencyWidget.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/widget/EmergencyWidget.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.widget;
+package co.median.android.a2025_theangels_new.data.widget;
 
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/educations/EducationActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/educations/EducationActivity.java
@@ -1,4 +1,4 @@
-package co.median.android.a2025_theangels_new.educations;
+package co.median.android.a2025_theangels_new.ui.educations;
 
 import android.os.Bundle;
 import android.util.Log;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/educations/EducationAdapter.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/educations/EducationAdapter.java
@@ -1,4 +1,4 @@
-package co.median.android.a2025_theangels_new.educations;
+package co.median.android.a2025_theangels_new.ui.educations;
 
 import android.content.Context;
 import android.content.Intent;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/educations/EducationDetailsActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/educations/EducationDetailsActivity.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.educations;
+package co.median.android.a2025_theangels_new.ui.educations;
 
 import android.content.Intent;
 import android.os.Bundle;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventUserActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventUserActivity.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.events.active;
+package co.median.android.a2025_theangels_new.ui.events.active;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import com.shuhart.stepview.StepView;
 import co.median.android.a2025_theangels_new.R;
-import co.median.android.a2025_theangels_new.map.StaticMapFragment;
+import co.median.android.a2025_theangels_new.data.map.StaticMapFragment;
 // =======================================
 // EventUserActivity - Handles the live event screen, step progression, and user feedback
 // =======================================

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventVolActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventVolActivity.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.events.active;
+package co.median.android.a2025_theangels_new.ui.events.active;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -17,10 +17,10 @@ import android.os.Handler;
 
 
 import co.median.android.a2025_theangels_new.R;
-import co.median.android.a2025_theangels_new.map.StaticMapFragment;
-import co.median.android.a2025_theangels_new.events.active.VolClaimFragment;
-import co.median.android.a2025_theangels_new.events.active.VolStatusFragment;
-import co.median.android.a2025_theangels_new.events.active.VolCloseFragment;
+import co.median.android.a2025_theangels_new.data.map.StaticMapFragment;
+import co.median.android.a2025_theangels_new.ui.events.active.VolClaimFragment;
+import co.median.android.a2025_theangels_new.ui.events.active.VolStatusFragment;
+import co.median.android.a2025_theangels_new.ui.events.active.VolCloseFragment;
 // =======================================
 // EventVolActivity - Handles the volunteer flow during an active event
 // =======================================

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolClaimFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolClaimFragment.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.events.active;
+package co.median.android.a2025_theangels_new.ui.events.active;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -15,18 +15,18 @@ import androidx.fragment.app.Fragment;
 import co.median.android.a2025_theangels_new.R;
 
 // =======================================
-// VolStatusFragment - Displays volunteer's event progress/status
+// VolClaimFragment - Fragment for the volunteer claim stage
 // =======================================
-public class VolStatusFragment extends Fragment {
+public class VolClaimFragment extends Fragment {
 
     // =======================================
-    // onCreateView - Inflates the layout for volunteer status UI
+    // onCreateView - Inflates the layout for volunteer claim UI
     // =======================================
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
                              @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_vol_status, container, false);
+        return inflater.inflate(R.layout.fragment_vol_claim, container, false);
     }
 }

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolCloseFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolCloseFragment.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.events.active;
+package co.median.android.a2025_theangels_new.ui.events.active;
 
 import android.content.DialogInterface;
 import android.content.Intent;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolStatusFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolStatusFragment.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.events.active;
+package co.median.android.a2025_theangels_new.ui.events.active;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -15,18 +15,18 @@ import androidx.fragment.app.Fragment;
 import co.median.android.a2025_theangels_new.R;
 
 // =======================================
-// VolClaimFragment - Fragment for the volunteer claim stage
+// VolStatusFragment - Displays volunteer's event progress/status
 // =======================================
-public class VolClaimFragment extends Fragment {
+public class VolStatusFragment extends Fragment {
 
     // =======================================
-    // onCreateView - Inflates the layout for volunteer claim UI
+    // onCreateView - Inflates the layout for volunteer status UI
     // =======================================
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
                              @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_vol_claim, container, false);
+        return inflater.inflate(R.layout.fragment_vol_status, container, false);
     }
 }

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/EventTypeFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/EventTypeFragment.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.events.create;
+package co.median.android.a2025_theangels_new.ui.events.create;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/NewEventActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/NewEventActivity.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.events.create;
+package co.median.android.a2025_theangels_new.ui.events.create;
 
 import android.content.Intent;
 import android.os.Build;
@@ -16,11 +16,11 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import co.median.android.a2025_theangels_new.R;
-import co.median.android.a2025_theangels_new.events.create.EventTypeFragment;
-import co.median.android.a2025_theangels_new.events.create.WhatHappenedFragment;
-import co.median.android.a2025_theangels_new.events.create.QuestionnaireFragment;
-import co.median.android.a2025_theangels_new.map.LocationFragment;
-import co.median.android.a2025_theangels_new.events.create.SummaryFragment;
+import co.median.android.a2025_theangels_new.ui.events.create.EventTypeFragment;
+import co.median.android.a2025_theangels_new.ui.events.create.WhatHappenedFragment;
+import co.median.android.a2025_theangels_new.ui.events.create.QuestionnaireFragment;
+import co.median.android.a2025_theangels_new.data.map.LocationFragment;
+import co.median.android.a2025_theangels_new.ui.events.create.SummaryFragment;
 import com.shuhart.stepview.StepView;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/QuestionnaireFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/QuestionnaireFragment.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.events.create;
+package co.median.android.a2025_theangels_new.ui.events.create;
 
 import android.graphics.Color;
 import android.os.Bundle;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/SummaryFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/SummaryFragment.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.events.create;
+package co.median.android.a2025_theangels_new.ui.events.create;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/WhatHappenedFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/WhatHappenedFragment.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.events.create;
+package co.median.android.a2025_theangels_new.ui.events.create;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/list/EventDetailsActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/list/EventDetailsActivity.java
@@ -1,7 +1,7 @@
 // =======================================
 // IMPORTS
 // =======================================
-package co.median.android.a2025_theangels_new.events.list;
+package co.median.android.a2025_theangels_new.ui.events.list;
 
 import android.os.Bundle;
 import android.location.Address;
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import co.median.android.a2025_theangels_new.R;
-import co.median.android.a2025_theangels_new.map.StaticMapFragment;
+import co.median.android.a2025_theangels_new.data.map.StaticMapFragment;
 import co.median.android.a2025_theangels_new.data.models.Event;
 import co.median.android.a2025_theangels_new.data.models.UserBasicInfo;
 import co.median.android.a2025_theangels_new.data.services.EventDataManager;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/list/EventsActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/list/EventsActivity.java
@@ -1,4 +1,4 @@
-package co.median.android.a2025_theangels_new.events.list;
+package co.median.android.a2025_theangels_new.ui.events.list;
 
 import android.os.Bundle;
 import android.util.Log;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/list/EventsAdapter.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/list/EventsAdapter.java
@@ -1,4 +1,4 @@
-package co.median.android.a2025_theangels_new.events.list;
+package co.median.android.a2025_theangels_new.ui.events.list;
 
 import android.content.Context;
 import android.content.Intent;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/list/RecentEventsAdapter.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/list/RecentEventsAdapter.java
@@ -1,4 +1,4 @@
-package co.median.android.a2025_theangels_new.events.list;
+package co.median.android.a2025_theangels_new.ui.events.list;
 
 import android.content.Context;
 import android.content.Intent;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/home/HomeActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/home/HomeActivity.java
@@ -32,10 +32,10 @@ import co.median.android.a2025_theangels_new.data.services.EventStatusDataManage
 import co.median.android.a2025_theangels_new.data.models.EventType;
 
 import co.median.android.a2025_theangels_new.R;
-import co.median.android.a2025_theangels_new.map.MapFragment;
+import co.median.android.a2025_theangels_new.data.map.MapFragment;
 import co.median.android.a2025_theangels_new.data.models.UserSession;
 import co.median.android.a2025_theangels_new.data.models.Event;
-import co.median.android.a2025_theangels_new.events.list.RecentEventsAdapter;
+import co.median.android.a2025_theangels_new.ui.events.list.RecentEventsAdapter;
 
 // =======================================
 // HomeActivity - Displays the home screen and handles location permission logic


### PR DESCRIPTION
## Summary
- move events and educations packages under `ui`
- move map, notifications and widget under `data`
- relocate `MyApplication` to `data`
- update package declarations and manifest entries

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856622a4d30833087fcf56b4fe47013