### PR TITLE
Fix missing BaseActivity imports

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventUserActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventUserActivity.java
@@ -21,6 +21,7 @@ import java.util.List;
 import com.shuhart.stepview.StepView;
 import co.median.android.a2025_theangels_new.R;
 import co.median.android.a2025_theangels_new.data.map.StaticMapFragment;
+import co.median.android.a2025_theangels_new.ui.main.BaseActivity;
 // =======================================
 // EventUserActivity - Handles the live event screen, step progression, and user feedback
 // =======================================

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventVolActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventVolActivity.java
@@ -21,6 +21,7 @@ import co.median.android.a2025_theangels_new.data.map.StaticMapFragment;
 import co.median.android.a2025_theangels_new.ui.events.active.VolClaimFragment;
 import co.median.android.a2025_theangels_new.ui.events.active.VolStatusFragment;
 import co.median.android.a2025_theangels_new.ui.events.active.VolCloseFragment;
+import co.median.android.a2025_theangels_new.ui.main.BaseActivity;
 // =======================================
 // EventVolActivity - Handles the volunteer flow during an active event
 // =======================================

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/NewEventActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/NewEventActivity.java
@@ -25,6 +25,7 @@ import com.shuhart.stepview.StepView;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import java.util.Arrays;
+import co.median.android.a2025_theangels_new.ui.main.BaseActivity;
 
 // =======================================
 // NewEventActivity - Multi-step form for creating a new event

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/list/EventDetailsActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/list/EventDetailsActivity.java
@@ -28,6 +28,7 @@ import co.median.android.a2025_theangels_new.data.models.UserBasicInfo;
 import co.median.android.a2025_theangels_new.data.services.EventDataManager;
 import co.median.android.a2025_theangels_new.data.services.UserDataManager;
 import com.bumptech.glide.Glide;
+import co.median.android.a2025_theangels_new.ui.main.BaseActivity;
 
 // =======================================
 // EventDetailsActivity - Displays event details screen including a static map

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/list/EventsActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/list/EventsActivity.java
@@ -15,6 +15,7 @@ import co.median.android.a2025_theangels_new.data.services.EventDataManager;
 import co.median.android.a2025_theangels_new.data.services.EventTypeDataManager;
 import co.median.android.a2025_theangels_new.data.services.EventStatusDataManager;
 import co.median.android.a2025_theangels_new.data.models.EventType;
+import co.median.android.a2025_theangels_new.ui.main.BaseActivity;
 
 public class EventsActivity extends BaseActivity {
 

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/home/HomeActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/home/HomeActivity.java
@@ -36,6 +36,7 @@ import co.median.android.a2025_theangels_new.data.map.MapFragment;
 import co.median.android.a2025_theangels_new.data.models.UserSession;
 import co.median.android.a2025_theangels_new.data.models.Event;
 import co.median.android.a2025_theangels_new.ui.events.list.RecentEventsAdapter;
+import co.median.android.a2025_theangels_new.ui.main.BaseActivity;
 
 // =======================================
 // HomeActivity - Displays the home screen and handles location permission logic

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/main/MainActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/main/MainActivity.java
@@ -23,6 +23,7 @@ import co.median.android.a2025_theangels_new.data.services.UserDataManager;
 import com.google.android.material.textfield.TextInputEditText;
 
 import co.median.android.a2025_theangels_new.R;
+import co.median.android.a2025_theangels_new.ui.main.BaseActivity;
 
 // =======================================
 // MainActivity - Handles login screen and navigation to registration or onboarding

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/profile/ProfileActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/profile/ProfileActivity.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 import com.bumptech.glide.Glide;
 import co.median.android.a2025_theangels_new.data.models.UserSession;
 import co.median.android.a2025_theangels_new.R;
+import co.median.android.a2025_theangels_new.ui.main.BaseActivity;
 
 // =======================================
 // ProfileActivity - Handles user profile screen and navigation to settings/help/logout

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/profile/settings/JoinVolSettingsActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/profile/settings/JoinVolSettingsActivity.java
@@ -6,6 +6,7 @@ package co.median.android.a2025_theangels_new.ui.profile.settings;
 import android.os.Bundle;
 
 import co.median.android.a2025_theangels_new.R;
+import co.median.android.a2025_theangels_new.ui.main.BaseActivity;
 
 // =======================================
 // JoinVolSettingsActivity - Displays settings screen for new volunteer registration


### PR DESCRIPTION
## Summary
- add `BaseActivity` import in activity classes that extend it

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685663debc4c833088d000caf3ca278c