### PR TITLE
Refactor UI resources with Material 3 styles

### DIFF
--- a/app/src/main/res/drawable/buttons/alert_button.xml
+++ b/app/src/main/res/drawable/buttons/alert_button.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/red_dark"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/app/src/main/res/drawable/buttons/primary_button.xml
+++ b/app/src/main/res/drawable/buttons/primary_button.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/button_primary"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/app/src/main/res/drawable/buttons/secondary_button.xml
+++ b/app/src/main/res/drawable/buttons/secondary_button.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/button_secondary"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/app/src/main/res/drawable/cards/default_card.xml
+++ b/app/src/main/res/drawable/cards/default_card.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/card_default_bg"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/drawable/cards/info_card.xml
+++ b/app/src/main/res/drawable/cards/info_card.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/card_info_bg"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/drawable/cards/warning_card.xml
+++ b/app/src/main/res/drawable/cards/warning_card.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/card_warning_bg"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/drawable/labels/chip_selected.xml
+++ b/app/src/main/res/drawable/labels/chip_selected.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/chip_selected_bg"/>
+    <corners android:radius="16dp"/>
+</shape>

--- a/app/src/main/res/drawable/labels/chip_unselected.xml
+++ b/app/src/main/res/drawable/labels/chip_unselected.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/chip_unselected_bg"/>
+    <corners android:radius="16dp"/>
+</shape>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -15,10 +15,10 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:id="@+id/volDashboard"
+            style="@style/Card.Info"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:padding="5dp"
-            android:background="@drawable/event_row_background"
             android:gravity="center"
             android:layout_marginBottom="16dp">
 
@@ -143,11 +143,10 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@drawable/notification_background"
+            style="@style/Card.Warning"
             android:orientation="horizontal"
             android:padding="12dp"
             android:gravity="center_vertical"
-            android:elevation="4dp"
             android:layout_marginBottom="16dp"
             android:visibility="gone">
 
@@ -183,13 +182,12 @@
 
         <LinearLayout
             android:id="@+id/location_permission_container"
+            style="@style/Card.Warning"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@drawable/location_permission_background"
             android:orientation="horizontal"
             android:padding="12dp"
             android:gravity="center_vertical"
-            android:elevation="4dp"
             android:layout_marginBottom="16dp"
             android:visibility="gone">
 
@@ -241,11 +239,10 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@drawable/good_to_know_background"
+            style="@style/Card.Info"
             android:orientation="horizontal"
             android:padding="12dp"
             android:gravity="center_vertical"
-            android:elevation="4dp"
             android:layout_marginBottom="16dp">
 
             <ImageView
@@ -283,10 +280,9 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@drawable/event_item_background"
+            style="@style/Card.Default"
             android:orientation="vertical"
             android:padding="12dp"
-            android:elevation="4dp"
             android:layout_marginBottom="16dp">
 
             <TextView

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -20,13 +20,11 @@
 
     <androidx.cardview.widget.CardView
         android:id="@+id/formCard"
+        style="@style/Card.Default"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="24dp"
         android:layout_marginHorizontal="24dp"
-        android:backgroundTint="#f1f3f4"
-        app:cardCornerRadius="16dp"
-        app:cardElevation="6dp"
         app:layout_constraintTop_toBottomOf="@id/loginText"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
@@ -38,7 +36,7 @@
             android:padding="20dp">
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                style="@style/InputField"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="12dp">
@@ -52,7 +50,7 @@
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                style="@style/InputField"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="12dp"
@@ -68,27 +66,15 @@
 
             <Button
                 android:id="@+id/loginButton"
-                android:layout_width="match_parent"
-                android:layout_height="50dp"
-                android:text="התחברות"
-                android:textColor="@android:color/white"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                android:elevation="6dp"
-                android:background="@drawable/rounded_button_blue"
-                android:layout_marginBottom="10dp"/>
+                style="@style/Button.Primary"
+                android:layout_marginBottom="10dp"
+                android:text="התחברות"/>
 
             <Button
                 android:id="@+id/registerButton"
-                android:layout_width="match_parent"
-                android:layout_height="50dp"
-                android:text="להרשמה לחצו כאן"
-                android:textColor="@android:color/white"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                android:elevation="6dp"
-                android:background="@drawable/rounded_button_green"
-                android:layout_marginTop="10dp"/>
+                style="@style/Button.Secondary"
+                android:layout_marginTop="10dp"
+                android:text="להרשמה לחצו כאן"/>
         </LinearLayout>
     </androidx.cardview.widget.CardView>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -104,4 +104,15 @@
     <color name="green_dark">#40916c</color>
     <color name="orange_warning_bg">#FFF3E0</color>
 
+    <!-- ///////////////////////////////////////////////////////////// -->
+    <!-- /////////////////////// UI COMPONENT COLORS ////////////////// -->
+    <!-- ///////////////////////////////////////////////////////////// -->
+    <color name="button_primary">@color/colorPrimary</color>
+    <color name="button_secondary">#76c893</color>
+    <color name="card_info_bg">@color/light_blue</color>
+    <color name="card_warning_bg">@color/orange_warning_bg</color>
+    <color name="card_default_bg">@color/white</color>
+    <color name="chip_selected_bg">@color/chip_selected</color>
+    <color name="chip_unselected_bg">@color/chip_unselected</color>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -123,4 +123,68 @@
         <item name="android:background">@android:color/darker_gray</item>
     </style>
 
+    <!-- ************************************************************* -->
+    <!-- *********************** DESIGN SYSTEM *********************** -->
+    <!-- ************************************************************* -->
+
+    <!-- Base button style -->
+    <style name="Button.Base" parent="Widget.Material3.Button">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">48dp</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/white</item>
+    </style>
+
+    <style name="Button.Primary" parent="Button.Base">
+        <item name="android:background">@drawable/buttons/primary_button</item>
+    </style>
+
+    <style name="Button.Secondary" parent="Button.Base">
+        <item name="android:background">@drawable/buttons/secondary_button</item>
+    </style>
+
+    <style name="Button.Alert" parent="Button.Base">
+        <item name="android:background">@drawable/buttons/alert_button</item>
+    </style>
+
+    <!-- Card styles -->
+    <style name="Card.Base" parent="Widget.Material3.CardView">
+        <item name="cardCornerRadius">8dp</item>
+        <item name="cardElevation">4dp</item>
+    </style>
+
+    <style name="Card.Info" parent="Card.Base">
+        <item name="android:background">@drawable/cards/info_card</item>
+    </style>
+
+    <style name="Card.Warning" parent="Card.Base">
+        <item name="android:background">@drawable/cards/warning_card</item>
+    </style>
+
+    <style name="Card.Default" parent="Card.Base">
+        <item name="android:background">@drawable/cards/default_card</item>
+    </style>
+
+    <!-- Input field style -->
+    <style name="InputField" parent="Widget.Material3.TextInputLayout.OutlinedBox">
+        <item name="boxBackgroundColor">@color/white</item>
+    </style>
+
+    <!-- Chip styles -->
+    <style name="Chip.Base">
+        <item name="android:paddingHorizontal">12dp</item>
+        <item name="android:paddingVertical">4dp</item>
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:gravity">center</item>
+    </style>
+
+    <style name="Chip.Selected" parent="Chip.Base">
+        <item name="android:background">@drawable/labels/chip_selected</item>
+    </style>
+
+    <style name="Chip.Unselected" parent="Chip.Base">
+        <item name="android:background">@drawable/labels/chip_unselected</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## Summary
- centralize component colors for Material 3
- add new drawable folders for buttons, cards and labels
- define Material 3 based styles for buttons, cards, inputs and chips
- apply new styles in `activity_main` and `activity_home`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68566f1a32ec833097de3324fceff723