### PR TITLE
Fix drawable references and Material3 styles

### DIFF
--- a/app/src/main/res/drawable/alert_button.xml
+++ b/app/src/main/res/drawable/alert_button.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/red_dark"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/app/src/main/res/drawable/chip_selected.xml
+++ b/app/src/main/res/drawable/chip_selected.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/chip_selected_bg"/>
+    <corners android:radius="16dp"/>
+</shape>

--- a/app/src/main/res/drawable/chip_unselected.xml
+++ b/app/src/main/res/drawable/chip_unselected.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/chip_unselected_bg"/>
+    <corners android:radius="16dp"/>
+</shape>

--- a/app/src/main/res/drawable/default_card.xml
+++ b/app/src/main/res/drawable/default_card.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/card_default_bg"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/drawable/info_card.xml
+++ b/app/src/main/res/drawable/info_card.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/card_info_bg"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/drawable/primary_button.xml
+++ b/app/src/main/res/drawable/primary_button.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/button_primary"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/app/src/main/res/drawable/secondary_button.xml
+++ b/app/src/main/res/drawable/secondary_button.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/button_secondary"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/app/src/main/res/drawable/warning_card.xml
+++ b/app/src/main/res/drawable/warning_card.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/card_warning_bg"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -136,33 +136,33 @@
     </style>
 
     <style name="Button.Primary" parent="Button.Base">
-        <item name="android:background">@drawable/buttons/primary_button</item>
+        <item name="android:background">@drawable/primary_button</item>
     </style>
 
     <style name="Button.Secondary" parent="Button.Base">
-        <item name="android:background">@drawable/buttons/secondary_button</item>
+        <item name="android:background">@drawable/secondary_button</item>
     </style>
 
     <style name="Button.Alert" parent="Button.Base">
-        <item name="android:background">@drawable/buttons/alert_button</item>
+        <item name="android:background">@drawable/alert_button</item>
     </style>
 
     <!-- Card styles -->
-    <style name="Card.Base" parent="Widget.Material3.CardView">
+    <style name="Card.Base" parent="Widget.Material3.MaterialCardView">
         <item name="cardCornerRadius">8dp</item>
         <item name="cardElevation">4dp</item>
     </style>
 
     <style name="Card.Info" parent="Card.Base">
-        <item name="android:background">@drawable/cards/info_card</item>
+        <item name="android:background">@drawable/info_card</item>
     </style>
 
     <style name="Card.Warning" parent="Card.Base">
-        <item name="android:background">@drawable/cards/warning_card</item>
+        <item name="android:background">@drawable/warning_card</item>
     </style>
 
     <style name="Card.Default" parent="Card.Base">
-        <item name="android:background">@drawable/cards/default_card</item>
+        <item name="android:background">@drawable/default_card</item>
     </style>
 
     <!-- Input field style -->
@@ -180,11 +180,12 @@
     </style>
 
     <style name="Chip.Selected" parent="Chip.Base">
-        <item name="android:background">@drawable/labels/chip_selected</item>
+        <item name="android:background">@drawable/chip_selected</item>
     </style>
 
     <style name="Chip.Unselected" parent="Chip.Base">
-        <item name="android:background">@drawable/labels/chip_unselected</item>
+        <item name="android:background">@drawable/chip_unselected</item>
     </style>
 
+    <style name="Chip" parent="Chip.Base" />
 </resources>


### PR DESCRIPTION
## Summary
- copy button, card, and chip drawables to the root `drawable` folder
- update style references to these drawables
- use `Widget.Material3.MaterialCardView` for card base style
- add generic `Chip` style alias

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68567122df808330942d169a695d7d6f