### PR TITLE
Implement new home screen map fragment

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/map/HomeMapFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/map/HomeMapFragment.java
@@ -1,0 +1,210 @@
+package co.median.android.a2025_theangels_new.data.map;
+
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.location.Location;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.LinearLayout;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
+
+import com.google.android.gms.location.LocationCallback;
+import com.google.android.gms.location.LocationResult;
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.OnMapReadyCallback;
+import com.google.android.gms.maps.SupportMapFragment;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.MapStyleOptions;
+import com.google.android.gms.maps.model.Marker;
+
+import co.median.android.a2025_theangels_new.R;
+
+/**
+ * פרגמנט הבית המציג מפה סטטית עם סימון מיקום המשתמש הנוכחי.
+ * אם אין הרשאת מיקום, מוצג מסר ברור להפעלת השירות.
+ */
+public class HomeMapFragment extends Fragment implements OnMapReadyCallback {
+
+    // =======================================
+    // משתנים פנימיים
+    // =======================================
+    private GoogleMap mMap;
+    private LocationService locationService;
+    private Marker userMarker;
+    private LinearLayout locationBox;
+
+    private OnAddressChangeListener addressChangeListener;
+
+    // משגר בקשת ההרשאה
+    private final ActivityResultLauncher<String> permissionLauncher =
+            registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+                if (isGranted) {
+                    showMap();
+                } else {
+                    showPermissionBox();
+                }
+            });
+
+    /**
+     * בנאי ברירת מחדל עם קישור לקובץ הפריסה.
+     */
+    public HomeMapFragment() {
+        super(R.layout.fragment_home_map);
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        addressChangeListener = null;
+    }
+
+    /** ממשק לקבלת כתובת מהמפה */
+    public interface OnAddressChangeListener {
+        void onAddressChanged(String address);
+    }
+
+    /** מאפשר להצמיד מאזין לשינוי הכתובת */
+    public void setAddressChangeListener(OnAddressChangeListener listener) {
+        this.addressChangeListener = listener;
+    }
+
+    /**
+     * אתחול רכיבי התצוגה והפעלת המפה הפנימית.
+     */
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        locationService = new LocationService(requireContext());
+        locationBox = view.findViewById(R.id.location_box);
+
+        SupportMapFragment mapFragment = (SupportMapFragment) getChildFragmentManager()
+                .findFragmentById(R.id.map);
+        if (mapFragment != null) {
+            mapFragment.getMapAsync(this);
+        }
+
+        // בקשת הרשאה בעת לחיצה על הקופסה
+        locationBox.setOnClickListener(v ->
+                permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION));
+    }
+
+    /**
+     * הפעלת עיצוב המפה ובדיקת הרשאות כאשר המפה מוכנה.
+     */
+    @Override
+    public void onMapReady(@NonNull GoogleMap googleMap) {
+        mMap = googleMap;
+        applyCustomStyle();
+        checkPermission();
+    }
+
+    /**
+     * בדיקת הרשאת מיקום וכיבוי/הפעלת התצוגה בהתאם.
+     */
+    private void checkPermission() {
+        if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.ACCESS_FINE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED) {
+            showMap();
+        } else {
+            showPermissionBox();
+        }
+    }
+
+    /**
+     * מציג את המפה ומתחיל בקבלת המיקום העדכני.
+     */
+    private void showMap() {
+        View mapView = requireView().findViewById(R.id.map);
+        mapView.setVisibility(View.VISIBLE);
+        locationBox.setVisibility(View.GONE);
+        startLocationUpdates();
+    }
+
+    /**
+     * מציג למשתמש את הקופסה המבקשת להפעיל שירותי מיקום.
+     */
+    private void showPermissionBox() {
+        View mapView = requireView().findViewById(R.id.map);
+        mapView.setVisibility(View.GONE);
+        locationBox.setVisibility(View.VISIBLE);
+        if (addressChangeListener != null) {
+            addressChangeListener.onAddressChanged(getString(R.string.address_not_found));
+        }
+    }
+
+    /**
+     * התחלת האזנה לעדכוני מיקום מהמכשיר.
+     */
+    private void startLocationUpdates() {
+        locationService.getCurrentLocation(new LocationService.SimpleLocationListener() {
+            @Override
+            public void onLocation(Location location) {
+                updateUserLocation(location);
+            }
+
+            @Override
+            public void onError(Exception e) {
+                // במידה ויש שגיאה, פשוט לא נעדכן
+            }
+        });
+
+        locationService.startLocationUpdates(new LocationCallback() {
+            @Override
+            public void onLocationResult(@NonNull LocationResult result) {
+                Location location = result.getLastLocation();
+                if (location != null) {
+                    updateUserLocation(location);
+                }
+            }
+        });
+    }
+
+    /**
+     * הפסקת האזנה לעדכוני המיקום בעת עצירת הפרגמנט.
+     */
+    private void stopLocationUpdates() {
+        locationService.stopLocationUpdates();
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        stopLocationUpdates();
+    }
+
+    /**
+     * עדכון מיקום המשתמש על המפה ודיווח הכתובת אם קיימת.
+     */
+    private void updateUserLocation(Location location) {
+        LatLng pos = new LatLng(location.getLatitude(), location.getLongitude());
+        if (userMarker == null) {
+            userMarker = MapHelper.addMarker(mMap, pos, getString(R.string.your_location));
+        } else {
+            userMarker.setPosition(pos);
+        }
+        MapHelper.moveCamera(mMap, pos, 15f);
+
+        if (addressChangeListener != null) {
+            String address = AddressHelper.getAddressFromLatLng(requireContext(), pos.latitude, pos.longitude);
+            if (address == null) address = getString(R.string.address_not_found);
+            addressChangeListener.onAddressChanged(address);
+        }
+    }
+
+    /**
+     * החלת סגנון מותאם ממקור המשאבים.
+     */
+    private void applyCustomStyle() {
+        try {
+            mMap.setMapStyle(MapStyleOptions.loadRawResourceStyle(requireContext(), R.raw.map_style));
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/home/HomeActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/home/HomeActivity.java
@@ -32,7 +32,7 @@ import co.median.android.a2025_theangels_new.data.services.EventStatusDataManage
 import co.median.android.a2025_theangels_new.data.models.EventType;
 
 import co.median.android.a2025_theangels_new.R;
-import co.median.android.a2025_theangels_new.data.map.MapFragment;
+import co.median.android.a2025_theangels_new.data.map.HomeMapFragment;
 import co.median.android.a2025_theangels_new.data.models.UserSession;
 import co.median.android.a2025_theangels_new.data.models.Event;
 import co.median.android.a2025_theangels_new.ui.events.list.RecentEventsAdapter;
@@ -41,7 +41,7 @@ import co.median.android.a2025_theangels_new.ui.main.BaseActivity;
 // =======================================
 // HomeActivity - Displays the home screen and handles location permission logic
 // =======================================
-public class HomeActivity extends BaseActivity implements MapFragment.OnAddressChangeListener {
+public class HomeActivity extends BaseActivity implements HomeMapFragment.OnAddressChangeListener {
 
     // =======================================
     // VARIABLES
@@ -128,7 +128,7 @@ public class HomeActivity extends BaseActivity implements MapFragment.OnAddressC
     // =======================================
     private void loadMapFragment() {
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
-        MapFragment fragment = new MapFragment();
+        HomeMapFragment fragment = new HomeMapFragment();
         fragment.setAddressChangeListener(this);
         transaction.replace(R.id.map_container, fragment);
         transaction.commit();

--- a/app/src/main/res/layout/fragment_home_map.xml
+++ b/app/src/main/res/layout/fragment_home_map.xml
@@ -1,0 +1,55 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/map_card"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="4dp">
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/map"
+            android:name="com.google.android.gms.maps.SupportMapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone" />
+    </com.google.android.material.card.MaterialCardView>
+
+    <LinearLayout
+        android:id="@+id/location_box"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/light_gray"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <ImageView
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:src="@drawable/icon_nomap" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/enable_location_services"
+            android:textColor="@android:color/black"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:gravity="center"
+            android:textAlignment="center" />
+
+        <TextView
+            android:id="@+id/btn_request_permission"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/request_location_permission"
+            android:textColor="@android:color/holo_blue_dark"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:paddingTop="4dp" />
+    </LinearLayout>
+
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,8 @@
     <string name="enable_permission_button">לחץ כאן לאפשר הרשאות</string>
     <string name="location_permission_settings_message">ניתן לאפשר את המיקום בהגדרות המכשיר.</string>
     <string name="open_settings_button">פתח הגדרות</string>
+    <string name="enable_location_services">הפעלת שירותי מיקום</string>
+    <string name="request_location_permission">לחץ כאן לאישור</string>
 
     <string name="id_field_locked">שדה זה לא ניתן לעריכה</string>
     <string name="fill_all_fields">נא למלא את כל השדות</string>


### PR DESCRIPTION
## Summary
- add `HomeMapFragment` using `LocationService` and `MapHelper`
- support permission banner and live location updates
- create modern material card layout for home map
- wire new fragment into `HomeActivity`
- add Hebrew strings for location prompts

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856b5a10cf08330808a8fba4d6ade2c