### PR TITLE
Implement message feed with navigation

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/services/EducationDataManager.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/services/EducationDataManager.java
@@ -63,4 +63,25 @@ public class EducationDataManager {
                     callback.onError(e);
                 });
     }
+
+    /**
+     * מחזיר הדרכה לפי מזהה מסמך.
+     */
+    public interface SingleEducationCallback {
+        void onEducationLoaded(Education education);
+        void onError(Exception e);
+    }
+
+    public static void getEducationById(@NonNull String id, SingleEducationCallback callback) {
+        FirebaseFirestore.getInstance().collection("education").document(id)
+                .get()
+                .addOnSuccessListener(doc -> {
+                    if (doc != null && doc.exists()) {
+                        callback.onEducationLoaded(doc.toObject(Education.class));
+                    } else {
+                        callback.onEducationLoaded(null);
+                    }
+                })
+                .addOnFailureListener(callback::onError);
+    }
 }

--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/services/MessageDataManager.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/services/MessageDataManager.java
@@ -1,9 +1,64 @@
-/**
- * מחלקת שירות עתידית לטיפול בהודעות במערכת.
- * כרגע אינה ממומשת.
- */
 package co.median.android.a2025_theangels_new.data.services;
 
+import android.util.Log;
+
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import co.median.android.a2025_theangels_new.data.models.Message;
+import co.median.android.a2025_theangels_new.data.models.MessageType;
+
+/**
+ * שירות לטיפול בהודעות המוצגות למשתמש.
+ */
 public class MessageDataManager {
-    // ניתן להוסיף כאן פונקציות לשליחה ושליפה של הודעות
+
+    private static final String TAG = "MessageDataManager";
+
+    public interface MessagesCallback {
+        void onMessagesLoaded(ArrayList<Message> messages, Map<String, MessageType> types);
+        void onError(Exception e);
+    }
+
+    /**
+     * טוען את כל סוגי ההודעות ואת ההודעות עצמן.
+     */
+    public static void getMessagesWithTypes(MessagesCallback callback) {
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+
+        db.collection("messageType").get()
+                .addOnSuccessListener(typeSnap -> {
+                    Map<String, MessageType> typeMap = new HashMap<>();
+                    for (DocumentSnapshot doc : typeSnap.getDocuments()) {
+                        MessageType type = doc.toObject(MessageType.class);
+                        if (type != null) {
+                            typeMap.put(type.getTypeName(), type);
+                        }
+                    }
+
+                    db.collection("messages").get()
+                            .addOnSuccessListener(msgSnap -> {
+                                ArrayList<Message> list = new ArrayList<>();
+                                for (DocumentSnapshot doc : msgSnap.getDocuments()) {
+                                    Message m = doc.toObject(Message.class);
+                                    if (m != null) {
+                                        list.add(m);
+                                    }
+                                }
+                                callback.onMessagesLoaded(list, typeMap);
+                            })
+                            .addOnFailureListener(e -> {
+                                Log.e(TAG, "Error fetching messages", e);
+                                callback.onError(e);
+                            });
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Error fetching message types", e);
+                    callback.onError(e);
+                });
+    }
 }

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/home/MessagesAdapter.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/home/MessagesAdapter.java
@@ -1,0 +1,110 @@
+package co.median.android.a2025_theangels_new.ui.home;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.bumptech.glide.Glide;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import co.median.android.a2025_theangels_new.R;
+import co.median.android.a2025_theangels_new.data.models.Message;
+import co.median.android.a2025_theangels_new.data.models.MessageType;
+
+public class MessagesAdapter extends ArrayAdapter<Message> {
+
+    public interface OnMessageClickListener {
+        void onMessageClicked(Message message);
+    }
+
+    private final Context context;
+    private final ArrayList<Message> messages;
+    private final int resource;
+    private Map<String, MessageType> typeMap;
+    private OnMessageClickListener clickListener;
+
+    public MessagesAdapter(@NonNull Context context, int resource, ArrayList<Message> messages) {
+        super(context, resource, messages);
+        this.context = context;
+        this.resource = resource;
+        this.messages = messages;
+    }
+
+    public void setTypeMap(Map<String, MessageType> typeMap) {
+        this.typeMap = typeMap;
+    }
+
+    public void setOnMessageClickListener(OnMessageClickListener listener) {
+        this.clickListener = listener;
+    }
+
+    @Override
+    public int getCount() {
+        return messages.size();
+    }
+
+    @Nullable
+    @Override
+    public Message getItem(int position) {
+        return messages.get(position);
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        if (convertView == null) {
+            convertView = LayoutInflater.from(context).inflate(resource, parent, false);
+        }
+
+        Message msg = getItem(position);
+        ImageView icon = convertView.findViewById(R.id.message_icon);
+        TextView typeView = convertView.findViewById(R.id.message_type);
+        TextView title = convertView.findViewById(R.id.message_title);
+        TextView content = convertView.findViewById(R.id.message_content);
+
+        if (msg != null) {
+            MessageType type = typeMap != null ? typeMap.get(msg.getMessageType()) : null;
+            if (type != null) {
+                typeView.setText(type.getTypeName());
+                try {
+                    int color = Color.parseColor(type.getColor());
+                    if (convertView.getBackground() instanceof GradientDrawable) {
+                        ((GradientDrawable) convertView.getBackground()).setColor(color);
+                    } else {
+                        convertView.setBackgroundColor(color);
+                    }
+                } catch (Exception ignored) {}
+
+                Glide.with(context.getApplicationContext())
+                        .load(type.getIconURL())
+                        .placeholder(R.drawable.messagebox_icon)
+                        .into(icon);
+            } else {
+                typeView.setText(msg.getMessageType());
+                icon.setImageResource(R.drawable.messagebox_icon);
+            }
+
+            title.setText(msg.getMessageTitle());
+            content.setText(msg.getMessageData());
+        }
+
+        convertView.setOnClickListener(v -> {
+            if (clickListener != null && msg != null && msg.getMessageRef() != null && !msg.getMessageRef().isEmpty()) {
+                clickListener.onMessageClicked(msg);
+            }
+        });
+
+        return convertView;
+    }
+}

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -138,48 +138,15 @@
 
 
 
-        <!-- Messages and Updates -->
+        <!-- Messages -->
 
         <LinearLayout
+            android:id="@+id/messages_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@drawable/notification_background"
-            android:orientation="horizontal"
-            android:padding="12dp"
-            android:gravity="center_vertical"
-            android:elevation="4dp"
+            android:orientation="vertical"
             android:layout_marginBottom="16dp"
-            android:visibility="gone">
-
-            <ImageView
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:src="@drawable/messagebox_icon"
-                android:contentDescription="הודעה"
-                android:layout_marginEnd="12dp"/>
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="vertical">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="הודעת מערכת חדשה"
-                    android:textSize="15sp"
-                    android:textStyle="bold"
-                    android:textColor="@android:color/black"/>
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="לאחר שיקלול הנתונים, הדירוג הכולל שלך עלה ל4.8, כל הכבוד! 👏🏻"
-                    android:textSize="14sp"
-                    android:textColor="@android:color/black"/>
-            </LinearLayout>
-        </LinearLayout>
+            android:visibility="gone"/>
 
         <LinearLayout
             android:id="@+id/location_permission_container"

--- a/app/src/main/res/layout/message_item.xml
+++ b/app/src/main/res/layout/message_item.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="12dp"
+    android:gravity="center_vertical"
+    android:background="@drawable/notification_background"
+    android:layout_marginBottom="8dp">
+
+    <ImageView
+        android:id="@+id/message_icon"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginEnd="12dp"
+        tools:src="@drawable/messagebox_icon" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/message_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textSize="14sp"
+            android:textColor="@android:color/black" />
+
+        <TextView
+            android:id="@+id/message_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textSize="15sp"
+            android:textColor="@android:color/black" />
+
+        <TextView
+            android:id="@+id/message_content"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textColor="@android:color/black" />
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add MessageDataManager service to pull message types and messages
- extend EducationDataManager with `getEducationById`
- create `MessagesAdapter` for rendering messages
- update `HomeActivity` to load messages and open education details when clicked
- insert message container in `activity_home.xml` and add `message_item` layout

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856bb4c9f1c8330a83e89ec42186f85