### PR TITLE
Fix message navigation to education details

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/home/HomeActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/home/HomeActivity.java
@@ -293,24 +293,32 @@ public class HomeActivity extends BaseActivity implements HomeMapFragment.OnAddr
     }
 
     private void handleMessageClick(Message message) {
-        if ("Education".equals(message.getMessageType())) {
-            EducationDataManager.getEducationById(message.getMessageRef(), new EducationDataManager.SingleEducationCallback() {
-                @Override
-                public void onEducationLoaded(Education education) {
-                    if (education != null) {
-                        Intent intent = new Intent(HomeActivity.this, EducationDetailsActivity.class);
-                        intent.putExtra("eduTitle", education.getEduTitle());
-                        intent.putExtra("eduData", education.getEduData());
-                        intent.putExtra("eduImageURL", education.getEduImageURL());
-                        startActivity(intent);
-                    }
-                }
-
-                @Override
-                public void onError(Exception e) {
-                }
-            });
+        String ref = message.getMessageRef();
+        if (ref == null || ref.isEmpty()) {
+            return;
         }
+
+        EducationDataManager.getEducationById(ref, new EducationDataManager.SingleEducationCallback() {
+            @Override
+            public void onEducationLoaded(Education education) {
+                if (education != null) {
+                    Intent intent = new Intent(HomeActivity.this, EducationDetailsActivity.class);
+                    intent.putExtra("id", ref);
+                    intent.putExtra("eduTitle", education.getEduTitle());
+                    intent.putExtra("eduData", education.getEduData());
+                    intent.putExtra("eduImageURL", education.getEduImageURL());
+                    intent.putExtra("eduType", education.getEduType());
+                    startActivity(intent);
+                } else {
+                    Toast.makeText(HomeActivity.this, R.string.education_not_found, Toast.LENGTH_SHORT).show();
+                }
+            }
+
+            @Override
+            public void onError(Exception e) {
+                Toast.makeText(HomeActivity.this, R.string.education_not_found, Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     // =======================================

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/home/MessagesAdapter.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/home/MessagesAdapter.java
@@ -99,11 +99,14 @@ public class MessagesAdapter extends ArrayAdapter<Message> {
             content.setText(msg.getMessageData());
         }
 
-        convertView.setOnClickListener(v -> {
-            if (clickListener != null && msg != null && msg.getMessageRef() != null && !msg.getMessageRef().isEmpty()) {
-                clickListener.onMessageClicked(msg);
-            }
-        });
+        boolean hasRef = msg != null && msg.getMessageRef() != null && !msg.getMessageRef().isEmpty();
+        convertView.setClickable(hasRef);
+
+        if (hasRef && clickListener != null) {
+            convertView.setOnClickListener(v -> clickListener.onMessageClicked(msg));
+        } else {
+            convertView.setOnClickListener(null);
+        }
 
         return convertView;
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -200,4 +200,5 @@
     <string name="select_cities_title">בחר ערים בהן תרצה להתנדב:</string>
     <string name="city_search_hint">הקלד עיר לחיפוש</string>
     <string name="city_already_selected">העיר כבר נבחרה</string>
+    <string name="education_not_found">תוכן ההדרכה לא נמצא</string>
 </resources>


### PR DESCRIPTION
## Summary
- make messages clickable only when `messageRef` exists
- show toast when referenced education is missing
- include id and type when navigating to education details
- add missing string for not found education content

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856bed40754833093c50347d6e80ea1