### PR TITLE
Improve new event report flow

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/NewEventActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/NewEventActivity.java
@@ -42,6 +42,7 @@ public class NewEventActivity extends BaseActivity {
     private StepView stepView;
     private TextView tvStepTitle, tvStepDescription;
     private Button btnNext;
+    private Button btnBack;
     private Vibrator vibrator;
     private NewEventViewModel viewModel;
 
@@ -67,6 +68,7 @@ public class NewEventActivity extends BaseActivity {
         stepView = findViewById(R.id.step_view);
         ImageView ivClose = findViewById(R.id.ivClose);
         btnNext = findViewById(R.id.btnNext);
+        btnBack = findViewById(R.id.btnBack);
         tvStepTitle = findViewById(R.id.tvStepTitle);
         tvStepDescription = findViewById(R.id.tvStepDescription);
         vibrator = (Vibrator) getSystemService(VIBRATOR_SERVICE);
@@ -87,6 +89,19 @@ public class NewEventActivity extends BaseActivity {
             updateStepInfo();
         }
 
+        btnBack.setEnabled(false);
+
+        btnBack.setOnClickListener(v -> {
+            if (currentStep > 0) {
+                currentStep--;
+                replaceFragment(steps[currentStep]);
+                stepView.go(currentStep, true);
+                updateStepInfo();
+                btnNext.setText(R.string.next_step);
+                btnBack.setEnabled(currentStep != 0);
+            }
+        });
+
         // Handle next step
         btnNext.setOnClickListener(v -> {
             if (currentStep < steps.length - 1) {
@@ -96,6 +111,7 @@ public class NewEventActivity extends BaseActivity {
                 updateStepInfo();
                 triggerVibration();
                 animateStepCircle();
+                btnBack.setEnabled(true);
 
                 // Update button text on last step
                 if (currentStep == steps.length - 1) {
@@ -118,8 +134,16 @@ public class NewEventActivity extends BaseActivity {
             }
         });
 
-        // Close screen
-        ivClose.setOnClickListener(v -> finish());
+        // Close screen with confirmation
+        ivClose.setOnClickListener(v -> new androidx.appcompat.app.AlertDialog.Builder(this)
+                .setMessage(R.string.cancel_event_creation_message)
+                .setPositiveButton(R.string.yes, (d, which) -> {
+                    viewModel.clear();
+                    startActivity(new Intent(NewEventActivity.this, co.median.android.a2025_theangels_new.ui.home.HomeActivity.class));
+                    finish();
+                })
+                .setNegativeButton(R.string.no, (d, which) -> d.dismiss())
+                .show());
     }
 
     // =======================================

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/NewEventViewModel.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/NewEventViewModel.java
@@ -51,6 +51,16 @@ public class NewEventViewModel extends ViewModel {
     }
 
     /**
+     * Clears all stored event data.
+     */
+    public void clear() {
+        eventType = null;
+        eventQuestionChoice = null;
+        eventForm.clear();
+        eventLocation = null;
+    }
+
+    /**
      * Creates a new event document in Firestore.
      */
     public void createEvent(String uid,

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/SummaryFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/create/SummaryFragment.java
@@ -14,6 +14,7 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
 import co.median.android.a2025_theangels_new.R;
+import co.median.android.a2025_theangels_new.data.map.AddressHelper;
 
 // =======================================
 // SummaryFragment - Final summary step in event creation
@@ -53,9 +54,14 @@ public class SummaryFragment extends Fragment {
             tvWhat.setText(getString(R.string.what_happened_label, viewModel.getEventQuestionChoice()));
         }
         if (tvLocation != null && viewModel.getEventLocation() != null) {
-            tvLocation.setText(getString(R.string.location_label,
-                    viewModel.getEventLocation().getLatitude(),
-                    viewModel.getEventLocation().getLongitude()));
+            double lat = viewModel.getEventLocation().getLatitude();
+            double lng = viewModel.getEventLocation().getLongitude();
+            String address = AddressHelper.getAddressFromLatLng(requireContext(), lat, lng);
+            if (address != null) {
+                tvLocation.setText(getString(R.string.location_label_address, address));
+            } else {
+                tvLocation.setText(getString(R.string.location_label, lat, lng));
+            }
         }
 
         if (llForm != null) {

--- a/app/src/main/res/layout/activity_new_event.xml
+++ b/app/src/main/res/layout/activity_new_event.xml
@@ -102,13 +102,30 @@
         android:padding="0dp"
         android:gravity="center"
         android:background="#ffffff"
-        android:elevation="6dp">
+        android:elevation="6dp"
+        android:orientation="horizontal">
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btnBack"
+            android:layout_width="0dp"
+            android:layout_height="64dp"
+            android:layout_weight="1"
+            android:text="@string/previous_step"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:textColor="#ffffff"
+            android:background="#6c757d"
+            android:padding="16dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:foreground="?android:attr/selectableItemBackground"/>
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btnNext"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="64dp"
-            android:text="המשך"
+            android:layout_weight="1"
+            android:text="@string/next_step"
             android:textSize="18sp"
             android:textStyle="bold"
             android:textColor="#ffffff"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,7 @@
 
     <string name="call_for_help">קריאה לעזרה</string>
     <string name="next_step">המשך</string>
+    <string name="previous_step">חזור</string>
 
     <!-- Location Permission -->
     <string name="location_permission_enabled">שיתוף מיקומך בזמן אמת פעיל</string>
@@ -102,6 +103,7 @@
     <string name="logout_message">האם אתה בטוח שברצונך להתנתק?</string>
     <string name="logout_yes">כן</string>
     <string name="logout_no">לא</string>
+    <string name="cancel_event_creation_message">האם אתה בטוח שברצונך לבטל יצירת האירוע?</string>
     <string name="yes">כן</string>
     <string name="no">לא</string>
 
@@ -122,6 +124,7 @@
     <string name="event_type_label">סוג אירוע: %1$s</string>
     <string name="what_happened_label">מה קרה: %1$s</string>
     <string name="location_label">מיקום: %1$.5f, %2$.5f</string>
+    <string name="location_label_address">מיקום: %1$s</string>
 
     <string name="close_event_dialog_title">בחר את סיבת סגירת האירוע</string>
     <string name="close_event_confirm">סיום</string>


### PR DESCRIPTION
## Summary
- show Hebrew address on summary step
- allow moving back and forth in New Event wizard
- add cancel confirmation for exit button
- add previous button to new event layout
- reset view model data on cancel

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856d164a0c08330b11ab024df370a19