### PR TITLE
Add active event logic

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/services/EventDataManager.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/services/EventDataManager.java
@@ -201,4 +201,48 @@ public class EventDataManager {
                 .document(eventId)
                 .addSnapshotListener(listener);
     }
+
+    /**
+     * Updates fields of an existing event document.
+     *
+     * @param eventId   ID of the event to update
+     * @param updates   map of fields and values to update
+     * @param onSuccess callback on successful update
+     * @param onError   callback on failure
+     */
+    public static void updateEvent(@NonNull String eventId,
+                                   @NonNull java.util.Map<String, Object> updates,
+                                   Runnable onSuccess,
+                                   ErrorCallback onError) {
+        FirebaseFirestore.getInstance().collection("events")
+                .document(eventId)
+                .update(updates)
+                .addOnSuccessListener(unused -> { if (onSuccess != null) onSuccess.run(); })
+                .addOnFailureListener(e -> { if (onError != null) onError.onError(e); });
+    }
+
+    /**
+     * Assigns a volunteer to handle the event and updates the status.
+     */
+    public static void claimEvent(@NonNull String eventId,
+                                  @NonNull String volunteerUid,
+                                  Runnable onSuccess,
+                                  ErrorCallback onError) {
+        java.util.Map<String, Object> updates = new java.util.HashMap<>();
+        updates.put("eventHandleBy", volunteerUid);
+        updates.put("eventStatus", "מתנדב בדרך");
+        updateEvent(eventId, updates, onSuccess, onError);
+    }
+
+    /**
+     * Updates only the eventStatus field.
+     */
+    public static void updateEventStatus(@NonNull String eventId,
+                                         @NonNull String status,
+                                         Runnable onSuccess,
+                                         ErrorCallback onError) {
+        java.util.Map<String, Object> updates = new java.util.HashMap<>();
+        updates.put("eventStatus", status);
+        updateEvent(eventId, updates, onSuccess, onError);
+    }
 }

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventUserActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventUserActivity.java
@@ -124,6 +124,13 @@ public class EventUserActivity extends BaseActivity {
                     Event event = snapshot.toObject(Event.class);
                     if (event != null && event.getEventStatus() != null) {
                         statusTextView.setText(event.getEventStatus());
+                        java.util.List<String> sts = java.util.Arrays.asList(
+                                getString(R.string.status_looking_for_volunteer),
+                                getString(R.string.status_volunteer_on_the_way),
+                                getString(R.string.status_volunteer_arrived),
+                                getString(R.string.status_event_finished));
+                        int i = sts.indexOf(event.getEventStatus());
+                        if (i >= 0) updateStep(i);
                     }
                 }
             });

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventVolActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventVolActivity.java
@@ -42,11 +42,17 @@ public class EventVolActivity extends BaseActivity {
     private FrameLayout mapContainer;
     private int currentStep = 0;
 
-    private List<Fragment> stepFragments = Arrays.asList(
-            new VolClaimFragment(),
-            new VolStatusFragment(),
-            new VolCloseFragment()
-    );
+    private String eventId;
+
+    private List<Fragment> stepFragments;
+
+    private void initFragments() {
+        stepFragments = Arrays.asList(
+                VolClaimFragment.newInstance(eventId),
+                VolStatusFragment.newInstance(eventId),
+                VolCloseFragment.newInstance(eventId)
+        );
+    }
     private ListenerRegistration eventListener;
 
     // =======================================
@@ -64,19 +70,28 @@ public class EventVolActivity extends BaseActivity {
         timerTextView = findViewById(R.id.timerTextView);
         mapContainer = findViewById(R.id.map_container);
 
+        eventId = getIntent().getStringExtra("eventId");
+
         startTimer();
         setupStepView();
         setupMap();
+
+        initFragments();
         loadStepFragment(0);
 
-        String eventId = getIntent().getStringExtra("eventId");
         if (eventId != null) {
             eventListener = EventDataManager.listenToEvent(eventId, (snapshot, e) -> {
                 if (e == null && snapshot != null && snapshot.exists()) {
                     Event event = snapshot.toObject(Event.class);
                     if (event != null && event.getEventStatus() != null) {
-                        //int index = statuses.indexOf(event.getEventStatus());
-                        //if (index >= 0) updateStep(index);
+                        java.util.List<String> statuses = java.util.Arrays.asList(
+                                getString(R.string.status_looking_for_volunteer),
+                                getString(R.string.status_volunteer_on_the_way),
+                                getString(R.string.status_volunteer_arrived),
+                                getString(R.string.status_event_finished)
+                        );
+                        int idx = statuses.indexOf(event.getEventStatus());
+                        if (idx >= 0 && idx < 3) updateStep(idx);
                     }
                 }
             });

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolClaimFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolClaimFragment.java
@@ -3,21 +3,46 @@
 // =======================================
 package co.median.android.a2025_theangels_new.ui.events.active;
 
+import android.app.AlertDialog;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
+import com.google.firebase.auth.FirebaseAuth;
+
 import co.median.android.a2025_theangels_new.R;
+import co.median.android.a2025_theangels_new.data.models.Event;
+import co.median.android.a2025_theangels_new.data.services.EventDataManager;
 
 // =======================================
 // VolClaimFragment - Fragment for the volunteer claim stage
 // =======================================
 public class VolClaimFragment extends Fragment {
+
+    private static final String ARG_EVENT_ID = "eventId";
+    private String eventId;
+
+    public static VolClaimFragment newInstance(String eventId) {
+        VolClaimFragment frag = new VolClaimFragment();
+        Bundle b = new Bundle();
+        b.putString(ARG_EVENT_ID, eventId);
+        frag.setArguments(b);
+        return frag;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            eventId = getArguments().getString(ARG_EVENT_ID);
+        }
+    }
 
     // =======================================
     // onCreateView - Inflates the layout for volunteer claim UI
@@ -28,5 +53,34 @@ public class VolClaimFragment extends Fragment {
                              @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_vol_claim, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        Button btnClaim = view.findViewById(R.id.btnClaimEvent);
+        Button btnNotInterested = view.findViewById(R.id.btnNotInterested);
+
+        if (btnClaim != null) {
+            btnClaim.setOnClickListener(v -> attemptClaimEvent());
+        }
+        if (btnNotInterested != null) {
+            btnNotInterested.setOnClickListener(v -> requireActivity().finish());
+        }
+    }
+
+    private void attemptClaimEvent() {
+        if (eventId == null) return;
+        String uid = FirebaseAuth.getInstance().getCurrentUser() != null ?
+                FirebaseAuth.getInstance().getCurrentUser().getUid() : null;
+        if (uid == null) return;
+
+        EventDataManager.claimEvent(eventId, uid, () -> {
+            AlertDialog.Builder b = new AlertDialog.Builder(requireContext());
+            b.setMessage(R.string.event_claimed).setPositiveButton(R.string.ok_button, (d, w) -> d.dismiss()).show();
+        }, e -> {
+            AlertDialog.Builder b = new AlertDialog.Builder(requireContext());
+            b.setMessage(R.string.error_title).setPositiveButton(R.string.ok_button, null).show();
+        });
     }
 }

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolCloseFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolCloseFragment.java
@@ -18,6 +18,8 @@ import androidx.fragment.app.Fragment;
 
 import co.median.android.a2025_theangels_new.R;
 import co.median.android.a2025_theangels_new.ui.home.HomeActivity;
+import co.median.android.a2025_theangels_new.data.services.EventDataManager;
+import com.google.firebase.firestore.FieldValue;
 
 // =======================================
 // VolCloseFragment - Allows the volunteer to close the event with a reason
@@ -27,9 +29,27 @@ public class VolCloseFragment extends Fragment {
     // =======================================
     // VARIABLES
     // =======================================
+    private static final String ARG_EVENT_ID = "eventId";
     private Button btnCloseEvent;
     private String selectedReason = null;
     private String[] closeReasons;
+    private String eventId;
+
+    public static VolCloseFragment newInstance(String eventId) {
+        VolCloseFragment f = new VolCloseFragment();
+        Bundle b = new Bundle();
+        b.putString(ARG_EVENT_ID, eventId);
+        f.setArguments(b);
+        return f;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            eventId = getArguments().getString(ARG_EVENT_ID);
+        }
+    }
 
     // =======================================
     // onCreateView - Inflates layout for closing event UI
@@ -71,7 +91,15 @@ public class VolCloseFragment extends Fragment {
 
         builder.setPositiveButton(getString(R.string.close_event_confirm), (dialog, which) -> {
             if (selectedReason != null) {
-                navigateToHome();
+                if (eventId != null) {
+                    java.util.Map<String, Object> updates = new java.util.HashMap<>();
+                    updates.put("eventCloseReason", selectedReason);
+                    updates.put("eventStatus", getString(R.string.status_event_finished));
+                    updates.put("eventTimeEnded", FieldValue.serverTimestamp());
+                    EventDataManager.updateEvent(eventId, updates, this::navigateToHome, null);
+                } else {
+                    navigateToHome();
+                }
             }
         });
 

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolStatusFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolStatusFragment.java
@@ -3,21 +3,45 @@
 // =======================================
 package co.median.android.a2025_theangels_new.ui.events.active;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import co.median.android.a2025_theangels_new.R;
+import co.median.android.a2025_theangels_new.data.map.MapHelper;
+import co.median.android.a2025_theangels_new.data.services.EventDataManager;
 
 // =======================================
 // VolStatusFragment - Displays volunteer's event progress/status
 // =======================================
 public class VolStatusFragment extends Fragment {
+
+    private static final String ARG_EVENT_ID = "eventId";
+    private String eventId;
+
+    public static VolStatusFragment newInstance(String eventId) {
+        VolStatusFragment f = new VolStatusFragment();
+        Bundle b = new Bundle();
+        b.putString(ARG_EVENT_ID, eventId);
+        f.setArguments(b);
+        return f;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            eventId = getArguments().getString(ARG_EVENT_ID);
+        }
+    }
 
     // =======================================
     // onCreateView - Inflates the layout for volunteer status UI
@@ -28,5 +52,44 @@ public class VolStatusFragment extends Fragment {
                              @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_vol_status, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        Button btnCall = view.findViewById(R.id.btnCall);
+        Button btnNavigate = view.findViewById(R.id.btnNavigate);
+        Button btnCancel = view.findViewById(R.id.btnCancelEvent);
+        Button btnArrived = view.findViewById(R.id.btnArrived);
+
+        if (btnCall != null) {
+            btnCall.setOnClickListener(v -> callUser());
+        }
+        if (btnNavigate != null) {
+            btnNavigate.setOnClickListener(v -> navigateToEvent());
+        }
+        if (btnCancel != null) {
+            btnCancel.setOnClickListener(v -> updateStatus(getString(R.string.status_event_finished)));
+        }
+        if (btnArrived != null) {
+            btnArrived.setOnClickListener(v -> updateStatus(getString(R.string.status_volunteer_arrived)));
+        }
+    }
+
+    private void callUser() {
+        if (getActivity() == null) return;
+        // Phone number should be fetched from event or user, placeholder below
+        Intent intent = new Intent(Intent.ACTION_DIAL, Uri.parse("tel:"));
+        startActivity(intent);
+    }
+
+    private void navigateToEvent() {
+        // Without actual coordinates we just open google maps
+        MapHelper.openNavigation(requireContext(), 0.0, 0.0);
+    }
+
+    private void updateStatus(String status) {
+        if (eventId == null) return;
+        EventDataManager.updateEventStatus(eventId, status, null, null);
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,6 +129,7 @@
     <string name="close_event_dialog_title">בחר את סיבת סגירת האירוע</string>
     <string name="close_event_confirm">סיום</string>
     <string name="close_event_cancel">ביטול</string>
+    <string name="event_claimed">האירוע שויך אליך</string>
 
     <!-- Manual address strings -->
     <string name="enter_address">הזן כתובת</string>


### PR DESCRIPTION
## Summary
- add event update utilities
- connect volunteer claim/close screens to Firestore
- update event progress listeners
- surface claim status strings

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856de8f1e608330a7e5dcadbee09381