### PR TITLE
Fix event handling and add rating persistence

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolClaimFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolClaimFragment.java
@@ -78,6 +78,9 @@ public class VolClaimFragment extends Fragment {
         EventDataManager.claimEvent(eventId, uid, () -> {
             AlertDialog.Builder b = new AlertDialog.Builder(requireContext());
             b.setMessage(R.string.event_claimed).setPositiveButton(R.string.ok_button, (d, w) -> d.dismiss()).show();
+            if (getActivity() instanceof EventVolActivity) {
+                ((EventVolActivity) getActivity()).advanceToStep(1);
+            }
         }, e -> {
             AlertDialog.Builder b = new AlertDialog.Builder(requireContext());
             b.setMessage(R.string.error_title).setPositiveButton(R.string.ok_button, null).show();

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolCloseFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/VolCloseFragment.java
@@ -41,7 +41,8 @@ public class VolCloseFragment extends Fragment {
             updates.put("eventCloseReason", reason);
             updates.put("eventStatus", getString(R.string.status_event_finished));
             updates.put("eventTimeEnded", FieldValue.serverTimestamp());
-            EventDataManager.updateEvent(eventId, updates, this::navigateToHome, null);
+            EventDataManager.updateEvent(eventId, updates, this::navigateToHome,
+                    e -> android.widget.Toast.makeText(requireContext(), R.string.error_title, android.widget.Toast.LENGTH_SHORT).show());
         } else {
             navigateToHome();
         }

--- a/app/src/main/res/layout/activity_event_user.xml
+++ b/app/src/main/res/layout/activity_event_user.xml
@@ -246,6 +246,24 @@
             android:visibility="gone">
 
             <TextView
+                android:id="@+id/closeReasonTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@android:color/black"
+                android:textSize="16sp"
+                android:padding="4dp"
+                android:visibility="gone"/>
+
+            <TextView
+                android:id="@+id/endTimeTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@android:color/black"
+                android:textSize="16sp"
+                android:padding="4dp"
+                android:visibility="gone"/>
+
+            <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/rate_volunteer"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,6 +207,8 @@
     <string name="enter_feedback">הכנס משוב חופשי</string>
     <string name="submit_rating">דירוג מתנדב</string>
     <string name="view_volunteer">מעבר לתצוגת המתנדב</string>
+    <string name="close_reason_label">סיבת סיום האירוע: %1$s</string>
+    <string name="end_time_label">האירוע הסתיים בשעה: %1$s</string>
 
     <string name="search_event_hint">חיפוש אירוע...</string>
     <string name="search_hint_event">חיפוש אירוע...</string>


### PR DESCRIPTION
## Summary
- save rating and feedback in event document
- show real event location on maps
- display close reason and end time for users
- allow volunteer flow to progress automatically
- add cancel reasons and error callbacks

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856edc5664883309da063552dfa045e