### PR TITLE
Fix event screen step syncing

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventUserActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventUserActivity.java
@@ -165,17 +165,17 @@ public class EventUserActivity extends BaseActivity {
                         if (status != null) {
                             statusTextView.setText(status);
                             java.util.List<String> sts = java.util.Arrays.asList(
-                                    getString(R.string.status_looking_for_volunteer),
-                                    getString(R.string.status_volunteer_on_the_way),
-                                    getString(R.string.status_volunteer_arrived),
-                                    getString(R.string.status_event_finished));
+                                    getString(R.string.step_looking),
+                                    getString(R.string.step_on_the_way),
+                                    getString(R.string.step_arrived),
+                                    getString(R.string.step_finished));
                             int i = sts.indexOf(status);
                             if (i >= 0) updateStep(i);
 
                             if ((previousStatus != null &&
-                                    previousStatus.equals(getString(R.string.status_looking_for_volunteer)) &&
-                                    status.equals(getString(R.string.status_volunteer_on_the_way))) ||
-                                    (previousStatus == null && status.equals(getString(R.string.status_volunteer_on_the_way)))) {
+                                    previousStatus.equals(getString(R.string.step_looking)) &&
+                                    status.equals(getString(R.string.step_on_the_way))) ||
+                                    (previousStatus == null && status.equals(getString(R.string.step_on_the_way)))) {
                                 triggerVolunteerAssigned(event.getEventHandleBy());
                             }
                             previousStatus = status;

--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventVolActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventVolActivity.java
@@ -102,10 +102,10 @@ public class EventVolActivity extends BaseActivity {
                         }
                         if (event.getEventStatus() != null) {
                             java.util.List<String> statuses = java.util.Arrays.asList(
-                                    getString(R.string.status_looking_for_volunteer),
-                                    getString(R.string.status_volunteer_on_the_way),
-                                    getString(R.string.status_volunteer_arrived),
-                                    getString(R.string.status_event_finished)
+                                    getString(R.string.step_looking),
+                                    getString(R.string.step_on_the_way),
+                                    getString(R.string.step_arrived),
+                                    getString(R.string.step_finished)
                             );
                             int idx = statuses.indexOf(event.getEventStatus());
                             if (idx >= 0 && idx < 3) updateStep(idx);


### PR DESCRIPTION
## Summary
- fix user event view step mapping by referencing step names instead of status texts
- sync volunteer event screen with same logic

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856f89dfd0c8330ab9bca129593415e