### PR TITLE
Fix Hebrew text for finished status

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/models/UserEventStatus.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/models/UserEventStatus.java
@@ -8,7 +8,7 @@ public enum UserEventStatus {
     LOOKING_FOR_VOLUNTEER("חיפוש מתנדב"),
     VOLUNTEER_ON_THE_WAY("מתנדב בדרך"),
     VOLUNTEER_AT_EVENT("מתנדב באירוע"),
-    EVENT_FINISHED("אירוע הסתיים");
+    EVENT_FINISHED("האירוע הסתיים");
 
     private final String dbValue;
 
@@ -31,6 +31,9 @@ public enum UserEventStatus {
             if (s.dbValue.equals(value)) {
                 return s;
             }
+        }
+        if ("אירוע הסתיים".equals(value)) {
+            return EVENT_FINISHED;
         }
         return null;
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="step_looking">חיפוש מתנדב</string>
     <string name="step_on_the_way">מתנדב בדרך</string>
     <string name="step_arrived">מתנדב באירוע</string>
-    <string name="step_finished">אירוע הסתיים</string>
+    <string name="step_finished">האירוע הסתיים</string>
 
     <string name="police_option">100 - משטרה</string>
     <string name="mda_option">101 - מגן דוד אדום</string>


### PR DESCRIPTION
## Summary
- correct Hebrew text for final event status
- handle legacy status values

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685703f49048833088fc4e2f159de92a