### PR TITLE
Fix Flogger configuration

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/MyApplication.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/MyApplication.java
@@ -16,6 +16,14 @@ public class MyApplication extends Application {
      */
     @Override
     public void onCreate() {
+        // Configure Flogger to use the Android backend before any
+        // libraries emit log messages. This prevents the frequent
+        // "Too many Flogger logs received before configuration" warnings
+        // that were appearing in Logcat.
+        System.setProperty(
+                "flogger.backend_factory",
+                "com.google.common.flogger.backend.android.AndroidBackendFactory");
+
         super.onCreate();
         FirebaseApp.initializeApp(this);
         FirebaseFirestore firestore = FirebaseFirestore.getInstance();


### PR DESCRIPTION
## Summary
- configure Flogger backend in `MyApplication` to avoid `Too many Flogger logs received before configuration`

## Testing
- `./gradlew test --dry-run` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68570576c35883309b0c9b18f01aaf67