### PR TITLE
Improve map style validation and logging

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/map/HomeMapFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/map/HomeMapFragment.java
@@ -20,10 +20,10 @@ import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.LatLng;
-import com.google.android.gms.maps.model.MapStyleOptions;
 import com.google.android.gms.maps.model.Marker;
 
 import co.median.android.a2025_theangels_new.R;
+import co.median.android.a2025_theangels_new.data.map.MapStyleHelper;
 
 /**
  * פרגמנט הבית המציג מפה סטטית עם סימון מיקום המשתמש הנוכחי.
@@ -202,9 +202,6 @@ public class HomeMapFragment extends Fragment implements OnMapReadyCallback {
      * החלת סגנון מותאם ממקור המשאבים.
      */
     private void applyCustomStyle() {
-        try {
-            mMap.setMapStyle(MapStyleOptions.loadRawResourceStyle(requireContext(), R.raw.map_style));
-        } catch (Exception ignored) {
-        }
+        MapStyleHelper.applyStyle(mMap, requireContext(), R.raw.map_style);
     }
 }

--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/map/LocationFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/map/LocationFragment.java
@@ -31,8 +31,8 @@ import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.LatLng;
-import com.google.android.gms.maps.model.MapStyleOptions;
 import com.google.android.gms.maps.model.Marker;
+import co.median.android.a2025_theangels_new.data.map.MapStyleHelper;
 
 import com.google.android.libraries.places.api.Places;
 import com.google.android.libraries.places.api.model.AutocompletePrediction;
@@ -380,9 +380,6 @@ public class LocationFragment extends Fragment implements OnMapReadyCallback {
     }
 
     private void applyCustomStyle() {
-        try {
-            mMap.setMapStyle(MapStyleOptions.loadRawResourceStyle(requireContext(), R.raw.map_style));
-        } catch (Exception ignored) {
-        }
+        MapStyleHelper.applyStyle(mMap, requireContext(), R.raw.map_style);
     }
 }

--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/map/MapFragment.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/map/MapFragment.java
@@ -40,10 +40,10 @@ import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLng;
-import com.google.android.gms.maps.model.MapStyleOptions;
 import com.google.android.gms.maps.model.MarkerOptions;
 
 import co.median.android.a2025_theangels_new.R;
+import co.median.android.a2025_theangels_new.data.map.MapStyleHelper;
 
 /**
  * פרגמנט המציג מפה ומאתר את מיקומו הנוכחי של המשתמש.
@@ -150,15 +150,7 @@ public class MapFragment extends Fragment implements OnMapReadyCallback {
     // applyCustomMapStyle - Applies custom map styling from raw/map_style.json
     // =======================================
     private void applyCustomMapStyle() {
-        try {
-            boolean success = mMap.setMapStyle(
-                    MapStyleOptions.loadRawResourceStyle(requireContext(), R.raw.map_style));
-            if (!success) {
-                System.out.println("Error applying map style.");
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        MapStyleHelper.applyStyle(mMap, requireContext(), R.raw.map_style);
     }
 
     // =======================================

--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/map/MapStyleHelper.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/map/MapStyleHelper.java
@@ -1,0 +1,73 @@
+package co.median.android.a2025_theangels_new.data.map;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.util.Log;
+
+import androidx.annotation.RawRes;
+
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.MapStyleOptions;
+
+import org.json.JSONArray;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+/**
+ * Utility methods for loading and applying Google Map style JSON safely.
+ */
+public class MapStyleHelper {
+    private static final String TAG = "MapStyleHelper";
+
+    /**
+     * Loads a map style resource after validating that the JSON is a valid array.
+     *
+     * @param context    Context used to access resources
+     * @param styleResId Raw resource ID of the style JSON
+     * @return {@link MapStyleOptions} if the JSON is valid, otherwise null
+     */
+    public static MapStyleOptions loadValidatedStyle(Context context, @RawRes int styleResId) {
+        Resources res = context.getResources();
+        try (InputStream input = res.openRawResource(styleResId);
+             BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
+            StringBuilder builder = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                builder.append(line);
+            }
+            String json = builder.toString().trim();
+            if (!json.startsWith("[") || !json.endsWith("]")) {
+                Log.e(TAG, "Map style JSON must be an array. See res/raw/map_style.json");
+                return null;
+            }
+            try {
+                new JSONArray(json); // validate JSON structure
+            } catch (Exception e) {
+                Log.e(TAG, "Invalid JSON in map style resource", e);
+                return null;
+            }
+            return MapStyleOptions.loadRawResourceStyle(context, styleResId);
+        } catch (Resources.NotFoundException e) {
+            Log.e(TAG, "Map style resource not found", e);
+        } catch (IOException e) {
+            Log.e(TAG, "Error reading map style", e);
+        }
+        return null;
+    }
+
+    /**
+     * Applies the given map style to the provided {@link GoogleMap} instance with logging.
+     */
+    public static void applyStyle(GoogleMap map, Context context, @RawRes int styleResId) {
+        MapStyleOptions options = loadValidatedStyle(context, styleResId);
+        if (options != null) {
+            boolean success = map.setMapStyle(options);
+            if (!success) {
+                Log.e(TAG, "Map style parsing failed");
+            }
+        }
+    }
+}

--- a/app/src/main/res/raw/map_style.json
+++ b/app/src/main/res/raw/map_style.json
@@ -1,23 +1,20 @@
-{
-  "version": 1,
-  "layers": [
-    {
-      "id": "land",
-      "stylers": [
-        { "color": "#f2efe9" }
-      ]
-    },
-    {
-      "id": "road",
-      "stylers": [
-        { "color": "#ffffff" }
-      ]
-    },
-    {
-      "id": "water",
-      "stylers": [
-        { "color": "#b5d0d0" }
-      ]
-    }
-  ]
-}
+[
+  {
+    "featureType": "landscape",
+    "stylers": [
+      { "color": "#f2efe9" }
+    ]
+  },
+  {
+    "featureType": "road",
+    "stylers": [
+      { "color": "#ffffff" }
+    ]
+  },
+  {
+    "featureType": "water",
+    "stylers": [
+      { "color": "#b5d0d0" }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- fix `map_style.json` formatting to be a JSON array
- introduce `MapStyleHelper` to validate JSON and apply styles safely
- use helper in `MapFragment`, `HomeMapFragment` and `LocationFragment`
- clean up imports and add clearer error logging

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685706ff47a8833097364a3d3edcd033