### PR TITLE
Fix duplicate EventStatus class name

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/data/models/EventStatusInfo.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/data/models/EventStatusInfo.java
@@ -1,16 +1,17 @@
-/**
- * מודל עבור סטטוס אפשרי של אירוע.
- */
 package co.median.android.a2025_theangels_new.data.models;
 
-public class EventStatus {
+/**
+ * Model representing an event status document stored in Firestore.
+ * מודל עבור סטטוס אפשרי של אירוע.
+ */
+public class EventStatusInfo {
     /** שם הסטטוס כפי שמופיע במסד */
     private String statusName;
     /** צבע המייצג את הסטטוס */
     private String statusColor;
 
     /** בנאי ריק הנדרש לפיירבייס */
-    public EventStatus() {}
+    public EventStatusInfo() {}
 
     /** @return שם הסטטוס */
     public String getStatusName() {


### PR DESCRIPTION
## Summary
- rename `EventStatusInfo` class from `EventStatus` to avoid name clash with the existing `EventStatus` enum

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68570aea46fc8330a26731b54435d21c