### PR TITLE
Improve active event volunteer card

### DIFF
--- a/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventUserActivity.java
+++ b/app/src/main/java/co/median/android/a2025_theangels_new/ui/events/active/EventUserActivity.java
@@ -34,7 +34,6 @@ import co.median.android.a2025_theangels_new.data.map.StaticMapFragment;
 import co.median.android.a2025_theangels_new.data.map.AddressHelper;
 import co.median.android.a2025_theangels_new.data.models.Event;
 import co.median.android.a2025_theangels_new.ui.main.BaseActivity;
-import com.airbnb.lottie.LottieAnimationView;
 // =======================================
 // EventUserActivity - Handles the live event screen, step progression, and user feedback
 // =======================================
@@ -55,7 +54,6 @@ public class EventUserActivity extends BaseActivity {
     private LinearLayout volunteerInfoLayout;
     private ImageView volunteerImage;
     private TextView volunteerName;
-    private LottieAnimationView volunteerAnimation;
     private LinearLayout ratingLayout;
     private LinearLayout safetyMessageLayout;
     private RatingBar ratingBar;
@@ -112,7 +110,6 @@ public class EventUserActivity extends BaseActivity {
         volunteerInfoLayout = binding.volunteerInfoLayout;
         volunteerImage = binding.volunteerImage;
         volunteerName = binding.volunteerName;
-        volunteerAnimation = binding.volunteerAnimation;
         closeReasonView = binding.closeReasonTextView;
         endTimeView = binding.endTimeTextView;
 
@@ -283,9 +280,7 @@ public class EventUserActivity extends BaseActivity {
             }
         }
         volunteerInfoLayout.setVisibility(View.VISIBLE);
-        if (volunteerAnimation != null) {
-            volunteerAnimation.playAnimation();
-        }
+        volunteerInfoLayout.startAnimation(android.view.animation.AnimationUtils.loadAnimation(this, android.R.anim.fade_in));
         UserDataManager.loadBasicUserInfo(uid, info -> {
             if (info != null) {
                 volunteerName.setText(info.getFirstName() + " " + info.getLastName());

--- a/app/src/main/res/drawable/volunteer_card_bg.xml
+++ b/app/src/main/res/drawable/volunteer_card_bg.xml
@@ -1,0 +1,7 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:startColor="@color/light_blue"
+        android:endColor="@android:color/white"
+        android:angle="270"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/app/src/main/res/layout/activity_event_user.xml
+++ b/app/src/main/res/layout/activity_event_user.xml
@@ -81,31 +81,46 @@
             android:visibility="gone"
             android:padding="8dp">
 
-            <com.airbnb.lottie.LottieAnimationView
-                android:id="@+id/volunteerAnimation"
-                android:layout_width="80dp"
-                android:layout_height="80dp"
-                app:lottie_rawRes="@raw/animation_hello"
-                app:lottie_autoPlay="false"
-                app:lottie_loop="false"/>
-
-            <ImageView
-                android:id="@+id/volunteerImage"
-                android:layout_width="80dp"
-                android:layout_height="80dp"
-                android:layout_marginTop="4dp"
-                android:src="@drawable/newuserpic"
-                android:background="@drawable/circle_image"
-                android:scaleType="centerCrop"/>
-
-            <TextView
-                android:id="@+id/volunteerName"
-                android:layout_width="wrap_content"
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/volunteerCard"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:textColor="@android:color/black"
-                android:textStyle="bold"
-                android:textSize="18sp"/>
+                android:layout_margin="8dp"
+                android:background="@drawable/volunteer_card_bg"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="4dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:gravity="center"
+                    android:padding="16dp"
+                    android:layoutDirection="rtl">
+
+                    <com.google.android.material.imageview.ShapeableImageView
+                        android:id="@+id/volunteerImage"
+                        android:layout_width="96dp"
+                        android:layout_height="96dp"
+                        android:src="@drawable/newuserpic"
+                        android:scaleType="centerCrop"
+                        app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Circle"
+                        app:strokeColor="@color/blue_primary"
+                        app:strokeWidth="1dp" />
+
+                    <TextView
+                        android:id="@+id/volunteerName"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:textColor="@android:color/black"
+                        android:textStyle="bold"
+                        android:textSize="20sp"
+                        android:drawableStart="@drawable/ic_star"
+                        android:drawableTint="@color/blue_primary"
+                        android:drawablePadding="4dp" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
         </LinearLayout>
 
         <TextView


### PR DESCRIPTION
## Summary
- redesign active event volunteer card with Material design
- add subtle gradient background drawable
- replace Lottie animation with fade-in transition

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68570e4c847c8330b0585af30b2d6151